### PR TITLE
Small links fix

### DIFF
--- a/gh_pages/_source/Debugging-Catkin-Workspace.rst
+++ b/gh_pages/_source/Debugging-Catkin-Workspace.rst
@@ -4,7 +4,7 @@ Debugging Catkin Workspace
 Prerequisite
 ------------
 
-#. Allow ptrace by following these `instructions <_source/Setup-Qt-Creator-for-ROS#31-setup-ubuntu-to-allow-debuggingptrace>`_
+#. Allow ptrace by following these `instructions <Setup-Qt-Creator-for-ROS#31-setup-ubuntu-to-allow-debuggingptrace>`_
 
 Attach to a unstarted process
 -----------------------------

--- a/gh_pages/_source/Setup-Qt-Creator-for-ROS.rst
+++ b/gh_pages/_source/Setup-Qt-Creator-for-ROS.rst
@@ -24,7 +24,7 @@ Set Syntax Color Schemes
 #. There is a drop down box in the "Color Scheme" group where you select different syntax color schemes.
 #. Addition schemes can be added as explained in the below links.
 
-   #. https://github.com/procedural/qtcreator-themes
+   #. https://github.com/welkineins/qtcreator-themes
    #. https://github.com/alexpana/qt-creator-wombat-theme
 
 Set ROS Code Format


### PR DESCRIPTION
Hello,

I just changed 2 dead links in the documentation : 

Setup-Qt-Creator-for-ROS.rst : the git 'procedural/qtcreator-themes' was removed ([link](https://github.com/procedural/qtcreator-themes))
Changed it to the fork : 'welkineins/qtcreator-themes'.

Debugging-Catkin-Workspace.rst: the link to 'Allow ptrace' was incorrect.
Normally it should be corrected. The link was "_source/_source/Debugging-Catkin-Workspace", I removed a '_source', but I didn't test it ([link](http://ros-industrial.github.io/ros_qtc_plugin/_source/_source/Setup-Qt-Creator-for-ROS#31-setup-ubuntu-to-allow-debuggingptrace))


