### PR TITLE
[4.4][doc] Add missing PPA for installation.

### DIFF
--- a/gh_pages/_source/Improve-ROS-Qt-Creator-Plugin-Developers-ONLY.rst
+++ b/gh_pages/_source/Improve-ROS-Qt-Creator-Plugin-Developers-ONLY.rst
@@ -11,6 +11,7 @@ Installation Procedure for Ubuntu 14.04
 
 .. code-block:: bash
 
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     sudo add-apt-repository ppa:levi-armstrong/qt-libraries-trusty
     sudo add-apt-repository ppa:levi-armstrong/ppa
     sudo apt-get update && sudo apt-get install qt57creator-plugin-ros libqtermwidget57-0-dev


### PR DESCRIPTION
https://github.com/ros-industrial/ros_qtc_plugin/issues/187#issuecomment-341571754

I'm only adding this to 14.04 but if this is necessary for Xenial let me know.