### PR TITLE
Replace `xacro.py` to `xacro --inorder`

### DIFF
--- a/share/templates/wizards/files/ros_industrial_robot/load.launch
+++ b/share/templates/wizards/files/ros_industrial_robot/load.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find %{PackageName})/urdf/%{Model}.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find %{PackageName})/urdf/%{Model}.xacro'" />
 </launch>


### PR DESCRIPTION
This PR fixes https://github.com/ros-industrial/industrial_training/issues/220 issue.

Environment:
- OS: Ubuntu 16.04
- ROS: Kinetic