### PR TITLE
Remove useo of -i argument when creating bash

### DIFF
--- a/gh_pages/_source/FAQ.rst
+++ b/gh_pages/_source/FAQ.rst
@@ -41,4 +41,8 @@ This can be for several reason.
 Environment variables in .bashrc are not loaded by Qt Creator.
 --------------------------------------------------------------
 
-The .bashrc is loaded by bash terminals and is not used by applications. In order for applications to get user defined environment variable they must be added to the .profile file in the users home directory.
+The .bashrc is loaded by bash terminals and is not used by applications. In order for applications to get user defined environment variables you have the two known option below.
+
+#. The environment variables can be added to the build configuration in Qt Creator of the project. This will be required for every new project created in Qt Creator.
+
+#. The environment variables can be added to the .profile file in the users home directory. This is only required once.

--- a/gh_pages/_source/FAQ.rst
+++ b/gh_pages/_source/FAQ.rst
@@ -36,3 +36,9 @@ This can be for several reason.
 
 #. Sometime is persist event if you address the previous items, but if code following is working then it should be ignored.
 
+.. _faq4:
+
+Environment variables in .bashrc are not loaded by Qt Creator.
+--------------------------------------------------------------
+
+The .bashrc is loaded by bash terminals and is not used by applications. In order for applications to get user defined environment variable they must be added to the .profile file in the users home directory.

--- a/src/project_manager/ros_catkin_make_step.cpp
+++ b/src/project_manager/ros_catkin_make_step.cpp
@@ -119,7 +119,7 @@ bool ROSCatkinMakeStep::init(QList<const BuildStep *> &earlierSteps)
     ProcessParameters *pp = processParameters();
     pp->setMacroExpander(bc->macroExpander());
     pp->setWorkingDirectory(bc->project()->projectDirectory().toString());
-    Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo).toStringList());
+    Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo, bc->environment()).toStringList());
 
     bc->updateQtEnvironment(env); // TODO: Not sure if this is required here
 
@@ -317,7 +317,7 @@ void ROSCatkinMakeStepWidget::updateDetails()
 
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
     ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->buildSystem(), bc->project()->distribution());
-    Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo).toStringList());
+    Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo, bc->environment()).toStringList());
 
     ProcessParameters param;
     param.setMacroExpander(bc->macroExpander());

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -127,7 +127,7 @@ bool ROSCatkinToolsStep::init(QList<const BuildStep *> &earlierSteps)
     // Set Catkin Tools Active Profile
     ROSUtils::setCatkinToolsActiveProfile(bc->project()->projectDirectory(), activeProfile());
     ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->buildSystem(), bc->project()->distribution());
-    Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo).toStringList());
+    Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo, bc->environment()).toStringList());
 
     bc->updateQtEnvironment(env); // TODO: Not sure if this is required here
 
@@ -396,7 +396,7 @@ void ROSCatkinToolsStepWidget::updateDetails()
 
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
     ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->buildSystem(), bc->project()->distribution());
-    Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo).toStringList());
+    Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo, bc->environment()).toStringList());
 
     m_ui->catkinToolsWorkingDirWidget->setEnvironment(env);
 

--- a/src/project_manager/ros_package_wizard.cpp
+++ b/src/project_manager/ros_package_wizard.cpp
@@ -347,7 +347,7 @@ bool ROSPackageWizard::writeFiles(const Core::GeneratedFiles &files, QString *er
   catkin_create_pkg->setWorkingDirectory(packagePath.toString());
 
   ROSUtils::sourceROS(catkin_create_pkg, project->distribution());
-  catkin_create_pkg->start(QLatin1String("bash"), QStringList() << QLatin1String("-i") << QLatin1String("-c") << cmd);
+  catkin_create_pkg->start(QLatin1String("bash"), QStringList() << QLatin1String("-c") << cmd);
   catkin_create_pkg->waitForFinished();
   bool success;
   if (catkin_create_pkg->exitStatus() != QProcess::CrashExit)

--- a/src/project_manager/ros_project.h
+++ b/src/project_manager/ros_project.h
@@ -86,7 +86,6 @@ private:
     ROSUtils::ROSProjectFileContent m_projectFileContent;
     ROSUtils::PackageInfoMap        m_wsPackageInfo;
     ROSUtils::PackageBuildInfoMap   m_wsPackageBuildInfo;
-    Utils::Environment              m_wsEnvironment;
 
     CppTools::CppProjectUpdater *m_cppCodeModelUpdater;
 
@@ -112,7 +111,6 @@ private:
       CppTools::RawProjectParts parts;
       ROSUtils::PackageInfoMap wsPackageInfo;
       ROSUtils::PackageBuildInfoMap wsPackageBuildInfo;
-      Utils::Environment wsEnvironment;
     };
 
     QFutureInterface<FutureWatcherResults> *m_asyncUpdateFutureInterface;

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -25,7 +25,6 @@
 #include "ros_project_plugin.h"
 
 #include <utils/fileutils.h>
-#include <utils/environment.h>
 #include <coreplugin/messagemanager.h>
 #include <yaml-cpp/yaml.h>
 #include <fstream>
@@ -494,13 +493,14 @@ ROSUtils::PackageInfoMap ROSUtils::getWorkspacePackageInfo(const WorkspaceInfo &
     return wsPackageInfo;
 }
 
-ROSUtils::PackageBuildInfoMap ROSUtils::getWorkspacePackageBuildInfo(const WorkspaceInfo &workspaceInfo, const PackageInfoMap &packageInfo, const PackageBuildInfoMap *cachedPackageBuildInfo)
+ROSUtils::PackageBuildInfoMap ROSUtils::getWorkspacePackageBuildInfo(const WorkspaceInfo &workspaceInfo,
+                                                                     const PackageInfoMap &packageInfo,
+                                                                     const PackageBuildInfoMap *cachedPackageBuildInfo)
 {
     PackageBuildInfoMap wsBuildInfo;
-    QStringList env = ROSUtils::getWorkspaceEnvironment(workspaceInfo).toStringList();
     for (const PackageInfo& package : packageInfo)
     {
-        PackageBuildInfo buildInfo(package, env);
+        PackageBuildInfo buildInfo(package);
         if (findPackageBuildDirectory(workspaceInfo, package, buildInfo.path))
         {
             // Get package's code block file
@@ -1086,9 +1086,12 @@ ROSUtils::WorkspaceInfo ROSUtils::getWorkspaceInfo(const Utils::FileName &worksp
     return space;
 }
 
-QProcessEnvironment ROSUtils::getWorkspaceEnvironment(const WorkspaceInfo &workspaceInfo)
+QProcessEnvironment ROSUtils::getWorkspaceEnvironment(const WorkspaceInfo &workspaceInfo, const Utils::Environment& current_environment)
 {
     QProcess process;
+
+    process.setProcessEnvironment(current_environment.toProcessEnvironment());
+
     sourceWorkspace(&process, workspaceInfo);
 
     QProcessEnvironment env = process.processEnvironment();

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -172,7 +172,7 @@ bool ROSUtils::initializeWorkspace(QProcess *process, const WorkspaceInfo &works
                     return false;
 
                 process->setWorkingDirectory(workspaceInfo.sourcePath.toString());
-                process->start(QLatin1String("bash"), QStringList() << QStringList() << QLatin1String("-i") << QLatin1String("-c") << QLatin1String("catkin_init_workspace"));
+                process->start(QLatin1String("bash"), QStringList() << QStringList() << QLatin1String("-c") << QLatin1String("catkin_init_workspace"));
 
                 if( !process->waitForFinished() )
                     return false;
@@ -191,7 +191,7 @@ bool ROSUtils::initializeWorkspace(QProcess *process, const WorkspaceInfo &works
                     return false;
 
                 process->setWorkingDirectory(workspace.path.toString());
-                process->start(QLatin1String("bash"), QStringList() << QLatin1String("-i") << QLatin1String("-c") << QLatin1String("catkin init"));
+                process->start(QLatin1String("bash"), QStringList() << QLatin1String("-c") << QLatin1String("catkin init"));
 
                 if( !process->waitForFinished() )
                     return false;
@@ -216,14 +216,14 @@ bool ROSUtils::buildWorkspace(QProcess *process, const WorkspaceInfo &workspaceI
     case CatkinMake:
     {
         process->setWorkingDirectory(workspaceInfo.path.toString());
-        process->start(QLatin1String("bash"), QStringList() << QLatin1String("-i") << QLatin1String("-c") << QLatin1String("catkin_make --cmake-args -G \"CodeBlocks - Unix Makefiles\""));
+        process->start(QLatin1String("bash"), QStringList() << QLatin1String("-c") << QLatin1String("catkin_make --cmake-args -G \"CodeBlocks - Unix Makefiles\""));
         process->waitForFinished();
         break;
     }
     case CatkinTools:
     {
         process->setWorkingDirectory(workspaceInfo.path.toString());
-        process->start(QLatin1String("bash"), QStringList() << QLatin1String("-i") << QLatin1String("-c") << QLatin1String("catkin build --cmake-args -G \"CodeBlocks - Unix Makefiles\""));
+        process->start(QLatin1String("bash"), QStringList() << QLatin1String("-c") << QLatin1String("catkin build --cmake-args -G \"CodeBlocks - Unix Makefiles\""));
         process->waitForFinished();
         break;
     }
@@ -253,7 +253,7 @@ bool ROSUtils::sourceWorkspaceHelper(QProcess *process, const QString &path)
   QStringList env_list;
   QString cmd = QLatin1String("source ") + path + QLatin1String(" && env");
 
-  process->start(QLatin1String("bash"), QStringList() << QLatin1String("-i"));
+  process->start(QLatin1String("bash"));
   process->waitForStarted();
   process->write(cmd.toLatin1());
   process->closeWriteChannel();
@@ -713,7 +713,7 @@ QMap<QString, QString> ROSUtils::getROSPackages(const QStringList &env)
   QStringList tmp;
 
   process.setEnvironment(env);
-  process.start(QLatin1String("bash"), QStringList() << QLatin1String("-i"));
+  process.start(QLatin1String("bash"));
   process.waitForStarted();
   QString cmd = QLatin1String("rospack list");
   process.write(cmd.toLatin1());
@@ -783,7 +783,7 @@ QMap<QString, QString> ROSUtils::getROSPackageExecutables(const QString &package
   QMap<QString, QString> package_executables;
 
   process.setEnvironment(env);
-  process.start(QLatin1String("bash"), QStringList() << QLatin1String("-i"));
+  process.start(QLatin1String("bash"));
   process.waitForStarted();
   QString cmd = QLatin1String("catkin_find --without-underlays --libexec ") + packageName;
   process.write(cmd.toLatin1());

--- a/src/project_manager/ros_utils.h
+++ b/src/project_manager/ros_utils.h
@@ -26,6 +26,7 @@
 #include <QXmlStreamWriter>
 #include <QRegularExpression>
 #include <utils/fileutils.h>
+#include <utils/environment.h>
 #include "ros_project_constants.h"
 
 namespace ROSProjectManager {
@@ -133,15 +134,13 @@ public:
 
     /** @brief Contains a packages relavent build informations */
     struct PackageBuildInfo {
-        PackageBuildInfo(const PackageInfo packageInfo, const QStringList env)
+        PackageBuildInfo(const PackageInfo packageInfo)
         {
             parent = packageInfo;
-            environment = env;
         }
 
         Utils::FileName path;          /**< @brief Path to the Package's build directory */
         Utils::FileName cbpFile;       /**< @brief Path to the Package's CodeBlocks file */
-        QStringList environment;       /**< @brief Build Environment */
         PackageTargetInfoList targets; /**< @brief List of packages target's */
         PackageInfo parent;            /**< @brief Package information */
 
@@ -426,7 +425,7 @@ public:
      * @param rosDistribution ROS distribution (Hydro, Indigo, etc.)
      * @return QProcessEnvironment
      */
-    static QProcessEnvironment getWorkspaceEnvironment(const WorkspaceInfo &workspaceInfo);
+    static QProcessEnvironment getWorkspaceEnvironment(const WorkspaceInfo &workspaceInfo, const Utils::Environment &current_environment);
 
 private:
     /**


### PR DESCRIPTION
Creating an interactive bash terminal as a child process was cause weird cpu spikes and crashes. This was originaly introduced to load environment variable added to the .bashrc. I have since found out that it is better to add environment variable to the .profile over the .bashrc so application like QtCreator get these since they are considered system level environment variables. I will add this to the wiki.