### PR TITLE
Fix selection of default and custom ROS distros

### DIFF
--- a/src/project_manager/ros_settings_page.cpp
+++ b/src/project_manager/ros_settings_page.cpp
@@ -89,7 +89,7 @@ void ROSSettings::fromSettings(QSettings *s)
 
     default_build_system = static_cast<ROSUtils::BuildSystem>(s->value(DEFAULT_BUILD_SYSTEM_ID, static_cast<int>(ROSUtils::BuildSystem::CatkinTools)).toInt());
     default_code_style = s->value(DEFAULT_CODE_STYLE_ID, "ROS").toString();
-    default_dist_path = s->value(CUSTOM_DISTRIBUTION_PATH_ID, Constants::ROS_INSTALL_DIRECTORY).toString();
+    default_dist_path = s->value(DEFAULT_DISTRIBUTION_PATH_ID, Constants::ROS_INSTALL_DIRECTORY).toString();
 
     if (default_dist_path.isEmpty())
       default_dist_path = Constants::ROS_INSTALL_DIRECTORY;

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -273,7 +273,13 @@ QList<Utils::FileName> ROSUtils::installedDistributions()
     {
       Utils::FileName path(custom_ros_path);
       path.appendPath(entry);
-      distributions.append(path);
+
+      Utils::FileName setup_file = path;
+      setup_file.appendString(QString("/setup.bash"));
+      if (setup_file.exists())
+      {
+        distributions.append(path);
+      }
     }
   }
 

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -268,6 +268,7 @@ QList<Utils::FileName> ROSUtils::installedDistributions()
   if(custom_ros_path.exists())
   {
     QDir custom_dir(custom_ros_path.toString());
+
     custom_dir.setFilter(QDir::NoDotAndDotDot | QDir::Dirs);
     for (auto entry : custom_dir.entryList())
     {
@@ -276,6 +277,7 @@ QList<Utils::FileName> ROSUtils::installedDistributions()
 
       Utils::FileName setup_file = path;
       setup_file.appendString(QString("/setup.bash"));
+
       if (setup_file.exists())
       {
         distributions.append(path);
@@ -287,12 +289,20 @@ QList<Utils::FileName> ROSUtils::installedDistributions()
   if (default_ros_path.exists())
   {
     QDir ros_opt(default_ros_path.toString());
+
     ros_opt.setFilter(QDir::NoDotAndDotDot | QDir::Dirs);
     for (auto entry : ros_opt.entryList())
     {
       Utils::FileName path = Utils::FileName::fromString(QLatin1String(ROSProjectManager::Constants::ROS_INSTALL_DIRECTORY));
       path.appendPath(entry);
-      distributions.append(path);
+
+      Utils::FileName setup_file = path;
+      setup_file.appendString(QString("/setup.bash"));
+
+      if (setup_file.exists())
+      {
+        distributions.append(path);
+      }
     }
   }
 


### PR DESCRIPTION
- Fixed initialization of the default ROS distro directory textbox. It was incorrectly initialized to the _custom_ ROS directory instead of the _default_ ROS directory.
- Added a filter on candidate ROS directories. Only directories containing a `setup.bash` file will be added to the dropdown menu.