### PR TITLE
Update enabling ptrace instructions

### DIFF
--- a/gh_pages/_source/Setup-Qt-Creator-for-ROS.rst
+++ b/gh_pages/_source/Setup-Qt-Creator-for-ROS.rst
@@ -4,9 +4,9 @@ Setup Qt Creator for ROS
 Setup Ubuntu to allow debugging/ptrace
 --------------------------------------
 
-#. Open file: :code:`sudo gedit /etc/rc.local`
-#. Add this line before the exit 0 line: :code:`echo 0 | tee /proc/sys/kernel/yama/ptrace_scope`
-#. Reboot computer
+#. Open file: :code:`sudo gedit /etc/sysctl.d/10-ptrace.conf`
+#. Change the value of :code:`kernel.yama.ptrace_scope` to 0
+#. Reload the kernel configuration with :code:`sudo systemctl restart procps.service`
 
 Set Theme
 ---------


### PR DESCRIPTION
The instructions involving the `rc.local` don't seem to be valid for Ubuntu Bionic and this seems to be a more official way to modify the value anyway. This is not a new way of configuring it so it should work for previous versions equally well.