### PR TITLE
port to Qt Creator 4.14

### DIFF
--- a/src/project_manager/ros_build_system.cpp
+++ b/src/project_manager/ros_build_system.cpp
@@ -21,5 +21,49 @@ void ROSBuildSystem::triggerParsing()
     guardParsingRun().markAsSuccess();
 }
 
+bool ROSBuildSystem::addFiles(ProjectExplorer::Node *context, const QStringList &filePaths, QStringList *notAdded)
+{
+    return true;
+}
+
+ProjectExplorer::RemovedFilesFromProject ROSBuildSystem::removeFiles(ProjectExplorer::Node *context, const QStringList &filePaths, QStringList *notRemoved)
+{
+    return ProjectExplorer::RemovedFilesFromProject::Ok;
+}
+
+bool ROSBuildSystem::deleteFiles(ProjectExplorer::Node *context, const QStringList &filePaths)
+{
+    return true;
+}
+
+bool ROSBuildSystem::canRenameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath)
+{
+    return true;
+}
+
+bool ROSBuildSystem::renameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath)
+{
+    return true;
+}
+
+bool ROSBuildSystem::addDependencies(ProjectExplorer::Node *context, const QStringList &dependencies)
+{
+    return true;
+}
+
+bool ROSBuildSystem::supportsAction(ProjectExplorer::Node *context, ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const
+{
+    static const std::set<ProjectAction> possible_actions = {
+        ProjectAction::AddNewFile,
+        ProjectAction::AddExistingFile,
+        ProjectAction::AddExistingDirectory,
+        ProjectAction::RemoveFile,
+        ProjectAction::EraseFile,
+        ProjectAction::Rename,
+    };
+
+    return possible_actions.count(action);
+}
+
 } // namespace Internal
 } // namespace ROSProjectManager

--- a/src/project_manager/ros_build_system.h
+++ b/src/project_manager/ros_build_system.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <projectexplorer/buildsystem.h>
+#include <projectexplorer/projectnodes.h>
 
 namespace ROSProjectManager {
 namespace Internal {
@@ -19,6 +20,15 @@ public:
     explicit ROSBuildSystem(ROSBuildConfiguration *bc);
 
     void triggerParsing() final;
+
+    virtual bool addFiles(ProjectExplorer::Node *context, const QStringList &filePaths, QStringList *notAdded = nullptr) final;
+    virtual ProjectExplorer::RemovedFilesFromProject removeFiles(ProjectExplorer::Node *context, const QStringList &filePaths,
+                                                                 QStringList *notRemoved = nullptr) final;
+    virtual bool deleteFiles(ProjectExplorer::Node *context, const QStringList &filePaths) final;
+    virtual bool canRenameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath) final;
+    virtual bool renameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath) final;
+    virtual bool addDependencies(ProjectExplorer::Node *context, const QStringList &dependencies) final;
+    virtual bool supportsAction(ProjectExplorer::Node *context, ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const final;
 };
 
 } // namespace Internal

--- a/src/project_manager/ros_catkin_make_step.cpp
+++ b/src/project_manager/ros_catkin_make_step.cpp
@@ -113,7 +113,6 @@ bool ROSCatkinMakeStep::init()
     env.set(QLatin1String("LC_ALL"), QLatin1String("C"));
     pp->setEnvironment(env);
     pp->setCommandLine(makeCommand(allArguments(bc->cmakeBuildType())));
-    pp->resolveAll();
 
     // If we are cleaning, then make can fail with an error code, but that doesn't mean
     // we should stop the clean queue

--- a/src/project_manager/ros_catkin_make_step.cpp
+++ b/src/project_manager/ros_catkin_make_step.cpp
@@ -211,11 +211,6 @@ void ROSCatkinMakeStep::stdOutput(const QString &line)
     }
 }
 
-BuildStepConfigWidget *ROSCatkinMakeStep::createConfigWidget()
-{
-    return new ROSCatkinMakeStepWidget(this);
-}
-
 ROSCatkinMakeStep::BuildTargets ROSCatkinMakeStep::buildTarget() const
 {
     return m_target;
@@ -231,8 +226,7 @@ void ROSCatkinMakeStep::setBuildTarget(const BuildTargets &target)
 //
 
 ROSCatkinMakeStepWidget::ROSCatkinMakeStepWidget(ROSCatkinMakeStep *makeStep)
-    : ProjectExplorer::BuildStepConfigWidget(makeStep)
-    , m_makeStep(makeStep)
+    : m_makeStep(makeStep)
 {
     m_ui = new Ui::ROSCatkinMakeStep;
     m_ui->setupUi(this);
@@ -294,7 +288,6 @@ void ROSCatkinMakeStepWidget::updateDetails()
     param.setEnvironment(bc->environment());
     param.setCommandLine(m_makeStep->makeCommand(m_makeStep->allArguments(bc->cmakeBuildType(), false)));
     m_summaryText = param.summary(displayName());
-    emit updateSummary();
 }
 
 void ROSCatkinMakeStepWidget::updateBuildSystem(const ROSUtils::BuildSystem &buildSystem)

--- a/src/project_manager/ros_catkin_make_step.h
+++ b/src/project_manager/ros_catkin_make_step.h
@@ -52,7 +52,6 @@ public:
 
     bool init() override;
     void setupOutputFormatter(Utils::OutputFormatter *formatter) override;
-    ProjectExplorer::BuildStepConfigWidget *createConfigWidget() override;
 
     ROSBuildConfiguration *rosBuildConfiguration() const;
     BuildTargets buildTarget() const;
@@ -77,7 +76,7 @@ private:
     QRegExp m_percentProgress;
 };
 
-class ROSCatkinMakeStepWidget : public ProjectExplorer::BuildStepConfigWidget
+class ROSCatkinMakeStepWidget : public QWidget
 {
     Q_OBJECT
 

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -40,7 +40,7 @@
 #include <utils/qtcassert.h>
 #include <utils/qtcprocess.h>
 #include <cmakeprojectmanager/cmakeparser.h>
-#include <coreplugin/variablechooser.h>
+#include <utils/variablechooser.h>
 #include <coreplugin/messagemanager.h>
 
 #include <fstream>
@@ -338,7 +338,7 @@ ROSCatkinToolsStepWidget::ROSCatkinToolsStepWidget(ROSCatkinToolsStep *makeStep)
     connect(ProjectExplorerPlugin::instance(), SIGNAL(settingsChanged()),
             this, SLOT(updateDetails()));
 
-    Core::VariableChooser::addSupportForChildWidgets(this, makeStep->rosBuildConfiguration()->macroExpander());
+    Utils::VariableChooser::addSupportForChildWidgets(this, makeStep->rosBuildConfiguration()->macroExpander());
 }
 
 ROSCatkinToolsStepWidget::~ROSCatkinToolsStepWidget()

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -237,11 +237,6 @@ void ROSCatkinToolsStep::stdOutput(const QString &line)
     }
 }
 
-BuildStepConfigWidget *ROSCatkinToolsStep::createConfigWidget()
-{
-    return new ROSCatkinToolsStepWidget(this);
-}
-
 ROSCatkinToolsStep::BuildTargets ROSCatkinToolsStep::buildTarget() const
 {
     return m_target;
@@ -267,8 +262,7 @@ void ROSCatkinToolsStep::setActiveProfile(const QString &profileName)
 //
 
 ROSCatkinToolsStepWidget::ROSCatkinToolsStepWidget(ROSCatkinToolsStep *makeStep)
-    : ProjectExplorer::BuildStepConfigWidget(makeStep)
-    , m_makeStep(makeStep)
+    : m_makeStep(makeStep)
 {
     m_ui = new Ui::ROSCatkinToolsStep;
     m_ui->setupUi(this);
@@ -376,7 +370,6 @@ void ROSCatkinToolsStepWidget::updateDetails()
     param.setWorkingDirectory(Utils::FilePath::fromString(m_makeStep->m_catkinToolsWorkingDir));
     param.setCommandLine(m_makeStep->makeCommand(m_makeStep->allArguments(bc->cmakeBuildType(), false)));
     m_summaryText = param.summary(displayName());
-    emit updateSummary();
 }
 
 void ROSCatkinToolsStepWidget::updateBuildSystem(const ROSUtils::BuildSystem &buildSystem)

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -126,7 +126,6 @@ bool ROSCatkinToolsStep::init()
     env.set(QLatin1String("LC_ALL"), QLatin1String("C"));
     pp->setEnvironment(env);
     pp->setCommandLine(makeCommand(allArguments(bc->cmakeBuildType())));
-    pp->resolveAll();
 
     // If we are cleaning, then make can fail with an error code, but that doesn't mean
     // we should stop the clean queue

--- a/src/project_manager/ros_catkin_tools_step.h
+++ b/src/project_manager/ros_catkin_tools_step.h
@@ -60,7 +60,6 @@ public:
 
     bool init() override;
     void setupOutputFormatter(Utils::OutputFormatter *formatter) override;
-    ProjectExplorer::BuildStepConfigWidget *createConfigWidget() override;
 
     ROSBuildConfiguration *rosBuildConfiguration() const;
     BuildTargets buildTarget() const;
@@ -92,7 +91,7 @@ private:
     QRegExp m_percentProgress;
 };
 
-class ROSCatkinToolsStepWidget : public ProjectExplorer::BuildStepConfigWidget
+class ROSCatkinToolsStepWidget : public QWidget
 {
     Q_OBJECT
 

--- a/src/project_manager/ros_colcon_step.cpp
+++ b/src/project_manager/ros_colcon_step.cpp
@@ -113,7 +113,6 @@ bool ROSColconStep::init()
     env.set(QLatin1String("LC_ALL"), QLatin1String("C"));
     pp->setEnvironment(env);
     pp->setCommandLine(makeCommand(allArguments(bc->cmakeBuildType())));
-    pp->resolveAll();
 
     // If we are cleaning, then make can fail with an error code, but that doesn't mean
     // we should stop the clean queue

--- a/src/project_manager/ros_colcon_step.cpp
+++ b/src/project_manager/ros_colcon_step.cpp
@@ -220,11 +220,6 @@ void ROSColconStep::stdOutput(const QString &line)
     }
 }
 
-BuildStepConfigWidget *ROSColconStep::createConfigWidget()
-{
-    return new ROSColconStepWidget(this);
-}
-
 ROSColconStep::BuildTargets ROSColconStep::buildTarget() const
 {
     return m_target;
@@ -240,8 +235,7 @@ void ROSColconStep::setBuildTarget(const BuildTargets &target)
 //
 
 ROSColconStepWidget::ROSColconStepWidget(ROSColconStep *makeStep)
-    : ProjectExplorer::BuildStepConfigWidget(makeStep)
-    , m_makeStep(makeStep)
+    : m_makeStep(makeStep)
 {
     m_ui = new Ui::ROSColconStep;
     m_ui->setupUi(this);
@@ -303,7 +297,6 @@ void ROSColconStepWidget::updateDetails()
     param.setEnvironment(bc->environment());
     param.setCommandLine(m_makeStep->makeCommand(m_makeStep->allArguments(bc->cmakeBuildType(), false)));
     m_summaryText = param.summary(displayName());
-    emit updateSummary();
 }
 
 void ROSColconStepWidget::updateBuildSystem(const ROSUtils::BuildSystem &buildSystem)

--- a/src/project_manager/ros_colcon_step.h
+++ b/src/project_manager/ros_colcon_step.h
@@ -52,7 +52,6 @@ public:
 
     bool init() override;
     void setupOutputFormatter(Utils::OutputFormatter *formatter) override;
-    ProjectExplorer::BuildStepConfigWidget *createConfigWidget() override;
 
     ROSBuildConfiguration *rosBuildConfiguration() const;
     BuildTargets buildTarget() const;
@@ -78,7 +77,7 @@ private:
     QRegExp m_percentProgress;
 };
 
-class ROSColconStepWidget : public ProjectExplorer::BuildStepConfigWidget
+class ROSColconStepWidget : public QWidget
 {
     Q_OBJECT
 

--- a/src/project_manager/ros_project.cpp
+++ b/src/project_manager/ros_project.cpp
@@ -475,7 +475,7 @@ void ROSProject::buildCppCodeModel(const ROSUtils::WorkspaceInfo workspaceInfo,
 
     ProjectExplorer::RawProjectParts rpps;
 
-    ToolChain *cxxToolChain = ToolChainKitAspect::toolChain(k, ProjectExplorer::Constants::CXX_LANGUAGE_ID);
+    const ToolChain *cxxToolChain = ToolChainKitAspect::cxxToolChain(k);
 
     QString pattern = "^.*\\.(" + QRegularExpression::escape("c") +
                             "|" + QRegularExpression::escape("cc") +
@@ -520,7 +520,10 @@ void ROSProject::buildCppCodeModel(const ROSUtils::WorkspaceInfo workspaceInfo,
             rpp.setMacros(ProjectExplorer::Macro::toMacros(defineArg.toUtf8()));
 
             QSet<QString> toolChainIncludes;
-            for (const HeaderPath &hp : cxxToolChain->builtInHeaderPaths(targetInfo.flags, sysRoot, env)) {
+            const HeaderPaths header_paths = \
+                    cxxToolChain->createBuiltInHeaderPathsRunner(env)\
+                    (targetInfo.flags, sysRoot.toString(), QString());
+            for (const HeaderPath &hp : header_paths) {
                 toolChainIncludes.insert(hp.path);
             }
 


### PR DESCRIPTION
This PR ports the plugin to the newest Qt Creator 4.14.

I ported from the 4.10 branch step-by-step. My forked repo https://github.com/christian-rauch/ros_qtc_plugin contains branches for 4.11, 4.12 and 4.13.

@Levi-Armstrong There are __many__ API breaking changes altogether. I verified that the 4.11, 4.12 and 4.13 branches can do the basic task of creating a workspace and compiling colcon packages, but I am mainly going to use the newest (4.14) release. Do you alternatively want to merge the 4.xx branches step-by-step?

Fixes #406 