### PR TITLE
port to Qt Creator 4.12

### DIFF
--- a/src/project_manager/ros_build_configuration.cpp
+++ b/src/project_manager/ros_build_configuration.cpp
@@ -92,33 +92,33 @@ void ROSBuildConfiguration::initialize(const ProjectExplorer::BuildInfo &info)
     {
         case ROSUtils::CatkinMake:
         {
-            ROSCatkinMakeStep *makeStep = new ROSCatkinMakeStep(bs);
+            ROSCatkinMakeStep *makeStep = new ROSCatkinMakeStep(bs, ROS_CMS_ID);
             bs->insertStep(0, makeStep);
             makeStep->setBuildTarget(ROSCatkinMakeStep::BUILD);
 
-            ROSCatkinMakeStep *cleanMakeStep = new ROSCatkinMakeStep(cs);
+            ROSCatkinMakeStep *cleanMakeStep = new ROSCatkinMakeStep(cs, ROS_CMS_ID);
             cs->insertStep(0, cleanMakeStep);
             cleanMakeStep->setBuildTarget(ROSCatkinMakeStep::CLEAN);
             break;
         }
         case ROSUtils::CatkinTools:
         {
-            ROSCatkinToolsStep *makeStep = new ROSCatkinToolsStep(bs);
+            ROSCatkinToolsStep *makeStep = new ROSCatkinToolsStep(bs, ROS_CTS_ID);
             bs->insertStep(0, makeStep);
             makeStep->setBuildTarget(ROSCatkinToolsStep::BUILD);
 
-            ROSCatkinToolsStep *cleanMakeStep = new ROSCatkinToolsStep(cs);
+            ROSCatkinToolsStep *cleanMakeStep = new ROSCatkinToolsStep(cs, ROS_CTS_ID);
             cs->insertStep(0, cleanMakeStep);
             cleanMakeStep->setBuildTarget(ROSCatkinToolsStep::CLEAN);
             break;
         }
         case ROSUtils::Colcon:
         {
-            ROSColconStep *makeStep = new ROSColconStep(bs);
+            ROSColconStep *makeStep = new ROSColconStep(bs, ROS_COLCON_STEP_ID);
             bs->insertStep(0, makeStep);
             makeStep->setBuildTarget(ROSColconStep::BUILD);
 
-            ROSColconStep *cleanMakeStep = new ROSColconStep(cs);
+            ROSColconStep *cleanMakeStep = new ROSColconStep(cs, ROS_COLCON_STEP_ID);
             cs->insertStep(0, cleanMakeStep);
             cleanMakeStep->setBuildTarget(ROSColconStep::CLEAN);
             break;

--- a/src/project_manager/ros_build_configuration.cpp
+++ b/src/project_manager/ros_build_configuration.cpp
@@ -68,6 +68,13 @@ ROSBuildConfiguration::ROSBuildConfiguration(Target *parent, Core::Id id)
     : BuildConfiguration(parent, id)
 {
     setInitializer(std::bind(&ROSBuildConfiguration::initialize, this, std::placeholders::_1));
+
+    m_build_system = new ROSBuildSystem(this);
+}
+
+ROSBuildConfiguration::~ROSBuildConfiguration()
+{
+    delete m_build_system;
 }
 
 void ROSBuildConfiguration::initialize(const ProjectExplorer::BuildInfo &info)
@@ -145,6 +152,11 @@ bool ROSBuildConfiguration::fromMap(const QVariantMap &map)
 ROSUtils::BuildSystem ROSBuildConfiguration::rosBuildSystem() const
 {
     return m_buildSystem;
+}
+
+BuildSystem *ROSBuildConfiguration::buildSystem() const
+{
+    return m_build_system;
 }
 
 void ROSBuildConfiguration::setBuildSystem(const ROSUtils::BuildSystem &buildSystem)

--- a/src/project_manager/ros_build_configuration.cpp
+++ b/src/project_manager/ros_build_configuration.cpp
@@ -278,7 +278,8 @@ BuildConfiguration::BuildType ROSBuildConfiguration::buildType() const
 ////////////////////////////////////////////////////////////////////////////////////
 
 ROSBuildSettingsWidget::ROSBuildSettingsWidget(ROSBuildConfiguration *bc)
-    : m_buildConfiguration(bc)
+    : NamedWidget(tr("ROS Manager")),
+      m_buildConfiguration(bc)
 {
     m_ui = new Ui::ROSBuildConfiguration;
     m_ui->setupUi(this);
@@ -293,8 +294,6 @@ ROSBuildSettingsWidget::ROSBuildSettingsWidget(ROSBuildConfiguration *bc)
 
     connect(m_ui->buildSourceWorkspaceButton, SIGNAL(clicked()),
             this, SLOT(buildSourceWorkspaceButtonClicked()));
-
-    setDisplayName(tr("ROS Manager"));
 }
 
 ROSBuildSettingsWidget::~ROSBuildSettingsWidget()
@@ -317,6 +316,7 @@ void ROSBuildSettingsWidget::buildTypeChanged(int index)
 ////////////////////////////////////////////////////////////////////////////////////
 
 ROSBuildEnvironmentWidget::ROSBuildEnvironmentWidget(BuildConfiguration *bc)
+    : NamedWidget(tr("Build Environment"))
 {
     QVBoxLayout *vbox = new QVBoxLayout(this);
     vbox->setMargin(0);
@@ -340,8 +340,6 @@ ROSBuildEnvironmentWidget::ROSBuildEnvironmentWidget(BuildConfiguration *bc)
     m_buildEnvironmentWidget->setBaseEnvironment(m_buildConfiguration->baseEnvironment());
     m_buildEnvironmentWidget->setBaseEnvironmentText(m_buildConfiguration->baseEnvironmentText());
     m_buildEnvironmentWidget->setUserChanges(m_buildConfiguration->userEnvironmentChanges());
-
-    setDisplayName(tr("Build Environment"));
 }
 
 void ROSBuildEnvironmentWidget::environmentModelUserChangesChanged()

--- a/src/project_manager/ros_build_configuration.cpp
+++ b/src/project_manager/ros_build_configuration.cpp
@@ -197,6 +197,8 @@ ROSBuildConfigurationFactory::ROSBuildConfigurationFactory() :
 
     setSupportedProjectType(Constants::ROS_PROJECT_ID);
     setSupportedProjectMimeTypeName(Constants::ROS_MIME_TYPE);
+
+    setBuildGenerator(std::bind(&ROSBuildConfigurationFactory::availableBuilds, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 }
 
 ROSBuildConfigurationFactory::~ROSBuildConfigurationFactory()
@@ -226,35 +228,35 @@ QList<BuildInfo> ROSBuildConfigurationFactory::availableBuilds(const Kit *k,
 
 ProjectExplorer::BuildInfo ROSBuildConfigurationFactory::createBuildInfo(const Kit *k, const ROSUtils::BuildSystem &build_system, const ROSUtils::BuildType &type) const
 {
-    ProjectExplorer::BuildInfo *info = new ProjectExplorer::BuildInfo(this);
-    info->kitId = k->id();
-    info->typeName = ROSUtils::buildTypeName(type);
-    info->displayName = info->typeName;
+    ProjectExplorer::BuildInfo info;
+    info.kitId = k->id();
+    info.typeName = ROSUtils::buildTypeName(type);
+    info.displayName = info.typeName;
 
     switch (type) {
     case ROSUtils::BuildTypeDebug:
-        info->buildType = BuildConfiguration::Debug;
+        info.buildType = BuildConfiguration::Debug;
         break;
     case ROSUtils::BuildTypeMinSizeRel:
-        info->buildType = BuildConfiguration::Release;
+        info.buildType = BuildConfiguration::Release;
         break;
     case ROSUtils::BuildTypeRelWithDebInfo:
-        info->buildType = BuildConfiguration::Profile;
+        info.buildType = BuildConfiguration::Profile;
         break;
     case ROSUtils::BuildTypeRelease:
-        info->buildType = BuildConfiguration::Release;
+        info.buildType = BuildConfiguration::Release;
         break;
     default:
-        info->buildType = BuildConfiguration::Unknown;
+        info.buildType = BuildConfiguration::Unknown;
         break;
     }
 
     ROSExtraBuildInfo extra;
     extra.buildSystem = build_system;
     extra.cmakeBuildType = type;
-    info->extraInfo = QVariant::fromValue(extra);
+    info.extraInfo = QVariant::fromValue(extra);
 
-    return *info;
+    return info;
 }
 
 BuildConfiguration::BuildType ROSBuildConfiguration::buildType() const

--- a/src/project_manager/ros_build_configuration.cpp
+++ b/src/project_manager/ros_build_configuration.cpp
@@ -137,7 +137,7 @@ bool ROSBuildConfiguration::fromMap(const QVariantMap &map)
   return BuildConfiguration::fromMap(map);
 }
 
-ROSUtils::BuildSystem ROSBuildConfiguration::buildSystem() const
+ROSUtils::BuildSystem ROSBuildConfiguration::rosBuildSystem() const
 {
     return m_buildSystem;
 }
@@ -277,7 +277,7 @@ ROSBuildSettingsWidget::ROSBuildSettingsWidget(ROSBuildConfiguration *bc)
 {
     m_ui = new Ui::ROSBuildConfiguration;
     m_ui->setupUi(this);
-    m_ui->buildSystemComboBox->setCurrentIndex(bc->buildSystem());
+    m_ui->buildSystemComboBox->setCurrentIndex(bc->rosBuildSystem());
     m_ui->buildTypeComboBox->setCurrentIndex(bc->cmakeBuildType());
 
     connect(m_ui->buildSystemComboBox, SIGNAL(currentIndexChanged(int)),
@@ -361,7 +361,7 @@ void ROSBuildEnvironmentWidget::environmentChanged()
 void ROSBuildSettingsWidget::buildSourceWorkspaceButtonClicked()
 {
   ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(m_buildConfiguration->project()->projectDirectory(),
-                                                                     m_buildConfiguration->buildSystem(),
+                                                                     m_buildConfiguration->rosBuildSystem(),
                                                                      m_buildConfiguration->project()->distribution());
 
   Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo, m_buildConfiguration->environment()).toStringList());

--- a/src/project_manager/ros_build_configuration.h
+++ b/src/project_manager/ros_build_configuration.h
@@ -57,7 +57,7 @@ class ROSBuildConfiguration : public ProjectExplorer::BuildConfiguration
 public:
     ROSBuildConfiguration(ProjectExplorer::Target *parent, Core::Id id);
 
-    void initialize() override;
+    void initialize(const ProjectExplorer::BuildInfo &info);
 
     ProjectExplorer::NamedWidget *createConfigWidget() override;
     QList<ProjectExplorer::NamedWidget *> createSubConfigWidgets() override;

--- a/src/project_manager/ros_build_configuration.h
+++ b/src/project_manager/ros_build_configuration.h
@@ -66,7 +66,7 @@ public:
 
     QVariantMap toMap() const override;
 
-    ROSUtils::BuildSystem buildSystem() const;
+    ROSUtils::BuildSystem rosBuildSystem() const;
     void setBuildSystem(const ROSUtils::BuildSystem &buildSystem);
 
     ROSUtils::BuildType cmakeBuildType() const;

--- a/src/project_manager/ros_build_configuration.h
+++ b/src/project_manager/ros_build_configuration.h
@@ -57,6 +57,8 @@ class ROSBuildConfiguration : public ProjectExplorer::BuildConfiguration
 public:
     ROSBuildConfiguration(ProjectExplorer::Target *parent, Core::Id id);
 
+    ~ROSBuildConfiguration();
+
     void initialize(const ProjectExplorer::BuildInfo &info);
 
     ProjectExplorer::NamedWidget *createConfigWidget() override;
@@ -68,6 +70,8 @@ public:
 
     ROSUtils::BuildSystem rosBuildSystem() const;
     void setBuildSystem(const ROSUtils::BuildSystem &buildSystem);
+
+    ProjectExplorer::BuildSystem *buildSystem() const override;
 
     ROSUtils::BuildType cmakeBuildType() const;
     void setCMakeBuildType(const ROSUtils::BuildType &buildType);
@@ -87,6 +91,7 @@ protected:
 
 private:
     ROSUtils::BuildSystem m_buildSystem;
+    ROSBuildSystem *m_build_system;
     ROSUtils::BuildType m_cmakeBuildType;
     ProjectExplorer::NamedWidget *m_buildEnvironmentWidget;
 

--- a/src/project_manager/ros_build_configuration.h
+++ b/src/project_manager/ros_build_configuration.h
@@ -102,7 +102,7 @@ public:
 
     QList<ProjectExplorer::BuildInfo> availableBuilds(const ProjectExplorer::Kit *k,
                                                       const Utils::FilePath &projectPath,
-                                                      bool forSetup) const override;
+                                                      bool forSetup) const;
 
 private:
     ProjectExplorer::BuildInfo createBuildInfo(const ProjectExplorer::Kit *k, const ROSUtils::BuildSystem &build_system, const ROSUtils::BuildType &type) const;

--- a/src/project_manager/ros_build_configuration.h
+++ b/src/project_manager/ros_build_configuration.h
@@ -94,8 +94,6 @@ private:
 
 class ROSBuildConfigurationFactory : public ProjectExplorer::BuildConfigurationFactory
 {
-    Q_OBJECT
-
 public:
     explicit ROSBuildConfigurationFactory();
     ~ROSBuildConfigurationFactory();

--- a/src/project_manager/ros_build_system.cpp
+++ b/src/project_manager/ros_build_system.cpp
@@ -1,7 +1,5 @@
 #include "ros_build_system.h"
 
-#include "ros_build_configuration.h"
-
 using namespace ProjectExplorer;
 
 namespace ROSProjectManager {
@@ -11,20 +9,15 @@ namespace Internal {
 // ROSBuildSystem:
 // --------------------------------------------------------------------
 
-ROSBuildSystem::ROSBuildSystem(ROSProject *p)
-    : BuildSystem(p)
+ROSBuildSystem::ROSBuildSystem(ROSBuildConfiguration *bc)
+    : BuildSystem((BuildConfiguration*)bc)
 {
     //
 }
 
-bool ROSBuildSystem::validateParsingContext(const ParsingContext &ctx)
+void ROSBuildSystem::triggerParsing()
 {
-    return ctx.project && qobject_cast<ROSBuildConfiguration *>(ctx.buildConfiguration);
-}
-
-void ROSBuildSystem::parseProject(ParsingContext &&ctx)
-{
-    ctx.guard.markAsSuccess();
+    guardParsingRun().markAsSuccess();
 }
 
 } // namespace Internal

--- a/src/project_manager/ros_build_system.cpp
+++ b/src/project_manager/ros_build_system.cpp
@@ -1,4 +1,5 @@
 #include "ros_build_system.h"
+#include "ros_build_configuration.h"
 
 using namespace ProjectExplorer;
 
@@ -12,7 +13,7 @@ namespace Internal {
 ROSBuildSystem::ROSBuildSystem(ROSBuildConfiguration *bc)
     : BuildSystem((BuildConfiguration*)bc)
 {
-    //
+    connect(((BuildConfiguration*)bc)->project(), &Project::activeTargetChanged, this, [this]() { triggerParsing(); });
 }
 
 void ROSBuildSystem::triggerParsing()

--- a/src/project_manager/ros_build_system.h
+++ b/src/project_manager/ros_build_system.h
@@ -5,7 +5,7 @@
 namespace ROSProjectManager {
 namespace Internal {
 
-class ROSProject;
+class ROSBuildConfiguration;
 
 // --------------------------------------------------------------------
 // ROSBuildSystem:
@@ -16,11 +16,9 @@ class ROSBuildSystem : public ProjectExplorer::BuildSystem
     Q_OBJECT
 
 public:
-    explicit ROSBuildSystem(ROSProject *project);
+    explicit ROSBuildSystem(ROSBuildConfiguration *bc);
 
-protected:
-    bool validateParsingContext(const ParsingContext &ctx) final;
-    void parseProject(ParsingContext &&ctx) final;
+    void triggerParsing() final;
 };
 
 } // namespace Internal

--- a/src/project_manager/ros_catkin_make_step.cpp
+++ b/src/project_manager/ros_catkin_make_step.cpp
@@ -48,7 +48,6 @@ using namespace ProjectExplorer;
 namespace ROSProjectManager {
 namespace Internal {
 
-const char ROS_CMS_ID[] = "ROSProjectManager.ROSCatkinMakeStep";
 const char ROS_CMS_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("ROSProjectManager::Internal::ROSCatkinMakeStep",
                                                      "CatkinMake Step");
 
@@ -57,19 +56,8 @@ const char ROS_CMS_CATKIN_MAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSCatkinMak
 const char ROS_CMS_CMAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSCatkinMakeStep.CMakeArguments";
 const char ROS_CMS_MAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSCatkinMakeStep.MakeArguments";
 
-ROSCatkinMakeStep::ROSCatkinMakeStep(BuildStepList *parent) :
-    AbstractProcessStep(parent, Id(ROS_CMS_ID))
-{
-    ctor();
-}
-
 ROSCatkinMakeStep::ROSCatkinMakeStep(BuildStepList *parent, const Id id) :
     AbstractProcessStep(parent, id)
-{
-    ctor();
-}
-
-void ROSCatkinMakeStep::ctor()
 {
     setDefaultDisplayName(QCoreApplication::translate("ROSProjectManager::Internal::ROSCatkinMakeStep",
                                                       ROS_CMS_DISPLAY_NAME));

--- a/src/project_manager/ros_catkin_make_step.cpp
+++ b/src/project_manager/ros_catkin_make_step.cpp
@@ -77,7 +77,7 @@ void ROSCatkinMakeStep::ctor()
     m_percentProgress = QRegExp(QLatin1String("\\[\\s{0,2}(\\d{1,3})%\\]")); // Example: [ 82%] [ 82%] [ 87%]
 
     ROSBuildConfiguration *bc = rosBuildConfiguration();
-    if (bc->buildSystem() != ROSUtils::CatkinMake)
+    if (bc->rosBuildSystem() != ROSUtils::CatkinMake)
         setEnabled(false);
 }
 
@@ -115,7 +115,7 @@ bool ROSCatkinMakeStep::init()
     }
 
     // TODO: Need to get build data (build directory, environment, etc.) based on build System
-    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->buildSystem(), bc->project()->distribution());
+    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->rosBuildSystem(), bc->project()->distribution());
 
     ProcessParameters *pp = processParameters();
     pp->setMacroExpander(bc->macroExpander());
@@ -297,7 +297,7 @@ void ROSCatkinMakeStepWidget::updateDetails()
     m_makeStep->m_makeArguments = m_ui->makeArgumentsLineEdit->text();
 
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
-    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->buildSystem(), bc->project()->distribution());
+    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->rosBuildSystem(), bc->project()->distribution());
 
     ProcessParameters param;
     param.setMacroExpander(bc->macroExpander());
@@ -316,7 +316,7 @@ void ROSCatkinMakeStepWidget::updateBuildSystem(const ROSUtils::BuildSystem &bui
 void ROSCatkinMakeStepWidget::enabledChanged()
 {
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
-    if(m_makeStep->enabled() && (bc->buildSystem() != ROSUtils::CatkinMake))
+    if(m_makeStep->enabled() && (bc->rosBuildSystem() != ROSUtils::CatkinMake))
         m_makeStep->setEnabled(false);
 }
 

--- a/src/project_manager/ros_catkin_make_step.h
+++ b/src/project_manager/ros_catkin_make_step.h
@@ -35,6 +35,8 @@ class ROSCatkinMakeStepWidget;
 class ROSCatkinMakeStepFactory;
 namespace Ui { class ROSCatkinMakeStep; }
 
+static const char ROS_CMS_ID[] = "ROSProjectManager.ROSCatkinMakeStep";
+
 class ROSCatkinMakeStep : public ProjectExplorer::AbstractProcessStep
 {
     Q_OBJECT
@@ -45,7 +47,7 @@ class ROSCatkinMakeStep : public ProjectExplorer::AbstractProcessStep
 public:
     enum BuildTargets {BUILD = 0, CLEAN = 1};
 
-    ROSCatkinMakeStep(ProjectExplorer::BuildStepList *parent);
+    ROSCatkinMakeStep(ProjectExplorer::BuildStepList *parent, Core::Id id);
     ~ROSCatkinMakeStep() override;
 
     bool init() override;
@@ -61,12 +63,10 @@ public:
     QVariantMap toMap() const override;
 
 protected:
-    ROSCatkinMakeStep(ProjectExplorer::BuildStepList *parent, Core::Id id);
     QStringList automaticallyAddedArguments() const;
     bool fromMap(const QVariantMap &map) override;
 
 private:
-    void ctor();
     ROSBuildConfiguration *targetsActiveBuildConfiguration() const;
 
     BuildTargets m_target;

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -53,7 +53,6 @@ using namespace ProjectExplorer;
 namespace ROSProjectManager {
 namespace Internal {
 
-const char ROS_CTS_ID[] = "ROSProjectManager.ROSCatkinToolsStep";
 const char ROS_CTS_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("ROSProjectManager::Internal::ROSCatkinToolsStep",
                                                      "CatkinTools Step");
 const char ROS_CTS_TARGET_KEY[] = "ROSProjectManager.ROSCatkinToolsStep.Target";
@@ -64,22 +63,11 @@ const char ROS_CTS_CATKIN_MAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSCatkinToo
 const char ROS_CTS_CMAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSCatkinToolsStep.CMakeArguments";
 const char ROS_CTS_MAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSCatkinToolsStep.MakeArguments";
 
-ROSCatkinToolsStep::ROSCatkinToolsStep(BuildStepList *parent) :
-    AbstractProcessStep(parent, Id(ROS_CTS_ID))
-{
-   m_catkinToolsWorkingDir = Constants::ROS_DEFAULT_WORKING_DIR;
-   ctor();
-}
-
 ROSCatkinToolsStep::ROSCatkinToolsStep(BuildStepList *parent, const Id id) :
     AbstractProcessStep(parent, id)
 {
     m_catkinToolsWorkingDir = Constants::ROS_DEFAULT_WORKING_DIR;
-    ctor();
-}
 
-void ROSCatkinToolsStep::ctor()
-{
     setDefaultDisplayName(QCoreApplication::translate("ROSProjectManager::Internal::ROSCatkinToolsStep",
                                                       ROS_CTS_DISPLAY_NAME));
 

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -291,7 +291,7 @@ ROSCatkinToolsStepWidget::ROSCatkinToolsStepWidget(ROSCatkinToolsStep *makeStep)
     m_ui->catkinToolsWorkingDirWidget->setPath(m_makeStep->m_catkinToolsWorkingDir);
     m_ui->catkinToolsWorkingDirWidget->setHistoryCompleter(QLatin1String("Qt.WorkingDir.History"));
     m_ui->catkinToolsWorkingDirWidget->setExpectedKind(Utils::PathChooser::Directory);
-    m_ui->catkinToolsWorkingDirWidget->setBaseFileName(makeStep->rosBuildConfiguration()->project()->projectDirectory());
+    m_ui->catkinToolsWorkingDirWidget->setFileName(makeStep->rosBuildConfiguration()->project()->projectDirectory());
 
     setProfile(m_makeStep->m_activeProfile);
 

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -89,7 +89,7 @@ void ROSCatkinToolsStep::ctor()
     m_percentProgress = QRegExp(QLatin1String(".+\\[(\\d+)/(\\d+) complete\\]")); // Example: [0/24 complete]
 
     ROSBuildConfiguration *bc = rosBuildConfiguration();
-    if (bc->buildSystem() != ROSUtils::CatkinTools)
+    if (bc->rosBuildSystem() != ROSUtils::CatkinTools)
         setEnabled(false);
 }
 
@@ -127,7 +127,7 @@ bool ROSCatkinToolsStep::init()
 
     // Set Catkin Tools Active Profile
     ROSUtils::setCatkinToolsActiveProfile(bc->project()->projectDirectory(), activeProfile());
-    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->buildSystem(), bc->project()->distribution());
+    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->rosBuildSystem(), bc->project()->distribution());
     Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo, bc->environment()).toStringList());
 
     bc->updateQtEnvironment(env); // TODO: Not sure if this is required here
@@ -376,7 +376,7 @@ void ROSCatkinToolsStepWidget::updateDetails()
     m_makeStep->m_catkinToolsWorkingDir = m_ui->catkinToolsWorkingDirWidget->rawPath();
 
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
-    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->buildSystem(), bc->project()->distribution());
+    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->rosBuildSystem(), bc->project()->distribution());
 
     m_ui->catkinToolsWorkingDirWidget->setEnvironment(bc->environment());
 
@@ -397,7 +397,7 @@ void ROSCatkinToolsStepWidget::updateBuildSystem(const ROSUtils::BuildSystem &bu
 void ROSCatkinToolsStepWidget::enabledChanged()
 {
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
-    if(m_makeStep->enabled() && (bc->buildSystem() != ROSUtils::CatkinTools))
+    if(m_makeStep->enabled() && (bc->rosBuildSystem() != ROSUtils::CatkinTools))
         m_makeStep->setEnabled(false);
 }
 

--- a/src/project_manager/ros_catkin_tools_step.h
+++ b/src/project_manager/ros_catkin_tools_step.h
@@ -43,6 +43,8 @@ namespace Ui {class ROSCatkinToolsStep;
               class ROSCatkinToolsListEditor;
               class ROSCatkinToolsConfigEditor;}
 
+static const char ROS_CTS_ID[] = "ROSProjectManager.ROSCatkinToolsStep";
+
 class ROSCatkinToolsStep : public ProjectExplorer::AbstractProcessStep
 {
     Q_OBJECT
@@ -53,7 +55,7 @@ class ROSCatkinToolsStep : public ProjectExplorer::AbstractProcessStep
 public:
     enum BuildTargets {BUILD = 0, CLEAN = 1};
 
-    ROSCatkinToolsStep(ProjectExplorer::BuildStepList *parent);
+    ROSCatkinToolsStep(ProjectExplorer::BuildStepList *parent, Core::Id id);
     ~ROSCatkinToolsStep() override;
 
     bool init() override;
@@ -73,12 +75,10 @@ public:
     QVariantMap toMap() const override;
 
 protected:
-    ROSCatkinToolsStep(ProjectExplorer::BuildStepList *parent, Core::Id id);
     QStringList automaticallyAddedArguments() const;
     bool fromMap(const QVariantMap &map) override;
 
 private:
-    void ctor();
     ROSBuildConfiguration *targetsActiveBuildConfiguration() const;
 
     BuildTargets m_target;

--- a/src/project_manager/ros_colcon_step.cpp
+++ b/src/project_manager/ros_colcon_step.cpp
@@ -77,7 +77,7 @@ void ROSColconStep::ctor()
     m_percentProgress = QRegExp(QLatin1String(".+\\[(\\d+)/(\\d+) complete\\]")); // Example: [0/24 complete]
 
     ROSBuildConfiguration *bc = rosBuildConfiguration();
-    if (bc->buildSystem() != ROSUtils::Colcon)
+    if (bc->rosBuildSystem() != ROSUtils::Colcon)
         setEnabled(false);
 }
 
@@ -115,7 +115,7 @@ bool ROSColconStep::init()
     }
 
     // TODO: Need to get build data (build directory, environment, etc.) based on build System
-    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->buildSystem(), bc->project()->distribution());
+    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->rosBuildSystem(), bc->project()->distribution());
 
     ProcessParameters *pp = processParameters();
     pp->setMacroExpander(bc->macroExpander());
@@ -306,7 +306,7 @@ void ROSColconStepWidget::updateDetails()
     m_makeStep->m_makeArguments = m_ui->makeArgumentsLineEdit->text();
 
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
-    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->buildSystem(), bc->project()->distribution());
+    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->rosBuildSystem(), bc->project()->distribution());
 
     ProcessParameters param;
     param.setMacroExpander(bc->macroExpander());
@@ -325,7 +325,7 @@ void ROSColconStepWidget::updateBuildSystem(const ROSUtils::BuildSystem &buildSy
 void ROSColconStepWidget::enabledChanged()
 {
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
-    if(m_makeStep->enabled() && (bc->buildSystem() != ROSUtils::Colcon))
+    if(m_makeStep->enabled() && (bc->rosBuildSystem() != ROSUtils::Colcon))
         m_makeStep->setEnabled(false);
 }
 

--- a/src/project_manager/ros_colcon_step.cpp
+++ b/src/project_manager/ros_colcon_step.cpp
@@ -48,7 +48,6 @@ using namespace ProjectExplorer;
 namespace ROSProjectManager {
 namespace Internal {
 
-const char ROS_COLCON_STEP_ID[] = "ROSProjectManager.ROSColconStep";
 const char ROS_COLCON_STEP_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("ROSProjectManager::Internal::ROSColconStep",
                                                      "Colcon Step");
 
@@ -57,19 +56,8 @@ const char ROS_COLCON_STEP_ARGUMENTS_KEY[] = "ROSProjectManager.ROSColconStep.Co
 const char ROS_COLCON_STEP_CMAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSColconStep.CMakeArguments";
 const char ROS_COLCON_STEP_MAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSColconStep.MakeArguments";
 
-ROSColconStep::ROSColconStep(BuildStepList *parent) :
-    AbstractProcessStep(parent, Id(ROS_COLCON_STEP_ID))
-{
-    ctor();
-}
-
 ROSColconStep::ROSColconStep(BuildStepList *parent, const Id id) :
     AbstractProcessStep(parent, id)
-{
-    ctor();
-}
-
-void ROSColconStep::ctor()
 {
     setDefaultDisplayName(QCoreApplication::translate("ROSProjectManager::Internal::ROSColconStep",
                                                       ROS_COLCON_STEP_DISPLAY_NAME));

--- a/src/project_manager/ros_colcon_step.h
+++ b/src/project_manager/ros_colcon_step.h
@@ -35,6 +35,8 @@ class ROSColconStepWidget;
 class ROSColconStepFactory;
 namespace Ui { class ROSColconStep; }
 
+static const char ROS_COLCON_STEP_ID[] = "ROSProjectManager.ROSColconStep";
+
 class ROSColconStep : public ProjectExplorer::AbstractProcessStep
 {
     Q_OBJECT
@@ -45,7 +47,7 @@ class ROSColconStep : public ProjectExplorer::AbstractProcessStep
 public:
     enum BuildTargets {BUILD = 0, CLEAN = 1};
 
-    ROSColconStep(ProjectExplorer::BuildStepList *parent);
+    ROSColconStep(ProjectExplorer::BuildStepList *parent, Core::Id id);
     ~ROSColconStep() override;
 
     bool init() override;
@@ -62,12 +64,10 @@ public:
     QVariantMap toMap() const override;
 
 protected:
-    ROSColconStep(ProjectExplorer::BuildStepList *parent, Core::Id id);
     QStringList automaticallyAddedArguments() const;
     bool fromMap(const QVariantMap &map) override;
 
 private:
-    void ctor();
     ROSBuildConfiguration *targetsActiveBuildConfiguration() const;
 
     BuildTargets m_target;

--- a/src/project_manager/ros_generic_run_step.cpp
+++ b/src/project_manager/ros_generic_run_step.cpp
@@ -76,7 +76,7 @@ void ROSGenericRunStep::run()
            m_target,
            m_arguments);
 
-  ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(rp->projectDirectory(), rp->rosBuildConfiguration()->buildSystem(), rp->distribution());
+  ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(rp->projectDirectory(), rp->rosBuildConfiguration()->rosBuildSystem(), rp->distribution());
   ROSBuildConfiguration *bc = qobject_cast<ROSBuildConfiguration *>(target()->activeBuildConfiguration());
   Utils::Environment env = bc->environment();
   Utils::FilePath shell = Utils::FilePath::fromString(env.value("SHELL"));

--- a/src/project_manager/ros_package_wizard.cpp
+++ b/src/project_manager/ros_package_wizard.cpp
@@ -259,7 +259,7 @@ Core::BaseFileWizard *ROSPackageWizard::create(QWidget *parent, const Core::Wiza
     if( bc )
     {
         ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(),
-                                                                           bc->buildSystem(),
+                                                                           bc->rosBuildSystem(),
                                                                            bc->project()->distribution());
 
         if( defaultPath ==  workspaceInfo.path.toString() )

--- a/src/project_manager/ros_project.cpp
+++ b/src/project_manager/ros_project.cpp
@@ -561,7 +561,7 @@ void ROSProject::updateCppCodeModel()
     m_wsPackageInfo = std::move(m_futureBuildCodeModelWatcher.result().wsPackageInfo);
     m_wsPackageBuildInfo = std::move(m_futureBuildCodeModelWatcher.result().wsPackageBuildInfo);
 
-    QtSupport::CppKitInfo kitInfo(this);
+    QtSupport::CppKitInfo kitInfo(this->activeTarget()->kit());
     QTC_ASSERT(kitInfo.isValid(), return);
 
     m_cppCodeModelUpdater->update({this, kitInfo, rosBuildConfiguration()->environment(), m_futureBuildCodeModelWatcher.result().parts});

--- a/src/project_manager/ros_project.cpp
+++ b/src/project_manager/ros_project.cpp
@@ -129,7 +129,6 @@ ROSProject::ROSProject(const Utils::FilePath &fileName) :
     ProjectExplorer::Project(Constants::ROS_MIME_TYPE, fileName),
     m_cppCodeModelUpdater(new CppTools::CppProjectUpdater),
     m_project_loaded(false),
-    m_build_system(nullptr),
     m_asyncUpdateFutureInterface(nullptr),
     m_asyncBuildCodeModelFutureInterface(nullptr)
 {
@@ -270,10 +269,6 @@ void ROSProject::updateProjectTree()
       asyncUpdateCppCodeModel(true);
     }
   }
-
-  // delete the build system and its parse guard to notify that parsing finished
-  delete m_build_system;
-  m_build_system = nullptr;
 }
 
 void ROSProject::buildProjectTree(const Utils::FilePath projectFilePath, const QStringList watchDirectories, QFutureInterface<FutureWatcherResults> &fi)
@@ -375,10 +370,7 @@ void ROSProject::fileSystemChanged(const QString &path)
 
 void ROSProject::asyncUpdate()
 {
-  if (!m_build_system) {
-      m_build_system = new ROSBuildSystem(rosBuildConfiguration());
-      m_build_system->requestParse();
-  }
+  rosBuildConfiguration()->buildSystem()->requestParse();
 
   m_futureWatcher.waitForFinished();
 

--- a/src/project_manager/ros_project.cpp
+++ b/src/project_manager/ros_project.cpp
@@ -376,7 +376,7 @@ void ROSProject::fileSystemChanged(const QString &path)
 void ROSProject::asyncUpdate()
 {
   if (!m_build_system) {
-      m_build_system = new ROSBuildSystem(this);
+      m_build_system = new ROSBuildSystem(rosBuildConfiguration());
       m_build_system->requestParse();
   }
 

--- a/src/project_manager/ros_project.cpp
+++ b/src/project_manager/ros_project.cpp
@@ -338,7 +338,7 @@ void ROSProject::updateEnvironment()
 {
   if (ROSBuildConfiguration *bc = rosBuildConfiguration())
   {
-    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(projectDirectory(), bc->buildSystem(), distribution());
+    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(projectDirectory(), bc->rosBuildSystem(), distribution());
     bc->updateQtEnvironment(Utils::Environment(ROSUtils::getWorkspaceEnvironment(workspaceInfo, bc->environment()).toStringList()));
   }
 }
@@ -420,7 +420,7 @@ void ROSProject::asyncUpdateCppCodeModel(bool success)
                                        tr("Parsing Build Files for Project \"%1\"").arg(displayName()),
                                        Constants::ROS_RELOADING_BUILD_INFO);
 
-        ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(projectDirectory(), rosBuildConfiguration()->buildSystem(), distribution());
+        ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(projectDirectory(), rosBuildConfiguration()->rosBuildSystem(), distribution());
         Utils::Environment current_environment = rosBuildConfiguration()->environment();
 
         const Kit *k = nullptr;

--- a/src/project_manager/ros_project.h
+++ b/src/project_manager/ros_project.h
@@ -97,7 +97,6 @@ private:
     QStringList m_workspaceFiles;
     QStringList m_workspaceDirectories;
     bool m_project_loaded;
-    ROSBuildSystem *m_build_system;
 
 
     struct FutureWatcherResults

--- a/src/project_manager/ros_project_nodes.cpp
+++ b/src/project_manager/ros_project_nodes.cpp
@@ -58,41 +58,6 @@ bool ROSProjectNode::showInSimpleTree() const
     return true;
 }
 
-bool ROSProjectNode::supportsAction(ProjectExplorer::ProjectAction action, const Node *node) const
-{
-    if(node->isProjectNodeType())
-    {
-        return action == ProjectAction::AddNewFile
-            || action == ProjectAction::RemoveFile
-            || action == ProjectAction::AddExistingFile;
-    }
-    else if(!node->isFolderNodeType() && !node->isProjectNodeType() && !node->isVirtualFolderType())
-    {
-        return action == ProjectAction::Rename
-            || action == ProjectAction::RemoveFile;
-    }
-
-    return ProjectNode::supportsAction(action, node);
-}
-
-bool ROSProjectNode::addFiles(const QStringList &filePaths, QStringList *notAdded)
-{
-  ProjectExplorer::ProjectNode::addFiles(filePaths, notAdded);
-  return true;
-}
-
-bool ROSProjectNode::deleteFiles(const QStringList &filePaths)
-{
-  ProjectExplorer::ProjectNode::deleteFiles(filePaths);
-  return true;
-}
-
-bool ROSProjectNode::renameFile(const QString &filePath, const QString &newFilePath)
-{
-  ProjectExplorer::ProjectNode::renameFile(filePath, newFilePath);
-  return true;
-}
-
 ROSFolderNode::ROSFolderNode(const Utils::FilePath &folderPath) : FolderNode(folderPath), m_repository(nullptr)
 {
     QString path = this->filePath().toString();

--- a/src/project_manager/ros_project_nodes.h
+++ b/src/project_manager/ros_project_nodes.h
@@ -43,14 +43,6 @@ public:
 
     bool showInSimpleTree() const override;
 
-    bool supportsAction(ProjectExplorer::ProjectAction action, const Node *node) const override;
-
-    bool addFiles(const QStringList &filePaths, QStringList *notAdded = nullptr) override;
-
-    bool deleteFiles(const QStringList &filePaths) override;
-
-    bool renameFile(const QString &filePath, const QString &newFilePath) override;
-
 private:
     static ProjectExplorer::FileNode *findFileNode(FolderNode *folder_node, const Utils::FilePath &filePaths);
 };

--- a/src/project_manager/ros_run_configuration.cpp
+++ b/src/project_manager/ros_run_configuration.cpp
@@ -86,11 +86,6 @@ QString ROSRunConfiguration::disabledReason() const
   return output;
 }
 
-QWidget *ROSRunConfiguration::createConfigurationWidget()
-{
-    return new RunStepsPage(this, Constants::ROS_RUN_STEPS_PAGE_ID);
-}
-
 QVariantMap ROSRunConfiguration::toMap() const
 {
     QVariantMap map(RunConfiguration::toMap());

--- a/src/project_manager/ros_run_configuration.cpp
+++ b/src/project_manager/ros_run_configuration.cpp
@@ -86,33 +86,6 @@ QString ROSRunConfiguration::disabledReason() const
   return output;
 }
 
-QVariantMap ROSRunConfiguration::toMap() const
-{
-    QVariantMap map(RunConfiguration::toMap());
-    map.insert(Constants::ROS_RUN_STEP_LIST_ID, m_stepList->toMap());
-
-    return map;
-}
-
-bool ROSRunConfiguration::fromMap(const QVariantMap &map)
-{
-    QVariantMap data = map.value(Constants::ROS_RUN_STEP_LIST_ID).toMap();
-    if (data.isEmpty()) {
-        Core::MessageManager::write(tr("[ROS Warning] No data for ROS run step list found!"));
-        return false;
-    }
-    RunStepList *list = new RunStepList(this, Constants::ROS_RUN_STEP_LIST_ID);
-    if (!list->fromMap(data)) {
-        Core::MessageManager::write(tr("[ROS Warning] Failed to restore ROS run step list!"));
-        delete list;
-        return false;
-    }
-
-    m_stepList = list;
-
-    return RunConfiguration::fromMap(map);
-}
-
 RunStepList* ROSRunConfiguration::stepList() const
 {
   return m_stepList;

--- a/src/project_manager/ros_run_configuration.h
+++ b/src/project_manager/ros_run_configuration.h
@@ -55,13 +55,7 @@ public:
     // RunConfiguration
     QString disabledReason() const override;
 
-    QVariantMap toMap() const override;
-
     RunStepList *stepList() const;
-
-protected:
-
-    virtual bool fromMap(const QVariantMap &map) override;
 
 private:
 

--- a/src/project_manager/ros_run_configuration.h
+++ b/src/project_manager/ros_run_configuration.h
@@ -55,8 +55,6 @@ public:
     // RunConfiguration
     QString disabledReason() const override;
 
-    virtual QWidget *createConfigurationWidget() override;
-
     QVariantMap toMap() const override;
 
     RunStepList *stepList() const;

--- a/src/project_manager/ros_run_step.cpp
+++ b/src/project_manager/ros_run_step.cpp
@@ -212,11 +212,6 @@ ProjectExplorer::Project *RunStep::project() const
     return target()->project();
 }
 
-bool RunStep::isActive() const
-{
-    return projectConfiguration()->isActive();
-}
-
 /*!
     If this function returns \c true, the user cannot delete this build step for
     this target and the user is prevented from changing the order in which
@@ -311,11 +306,6 @@ bool RunStepList::enabled() const
             return true;
     }
     return false;
-}
-
-bool RunStepList::isActive() const
-{
-    return qobject_cast<ProjectConfiguration *>(parent())->isActive();
 }
 
 bool RunStepList::fromMap(const QVariantMap &map)

--- a/src/project_manager/ros_run_step.h
+++ b/src/project_manager/ros_run_step.h
@@ -66,8 +66,6 @@ public:
     ProjectExplorer::Target *target() const;
     ProjectExplorer::Project *project() const;
 
-    bool isActive() const override;
-
 signals:
     void finished();
     void enabledChanged();
@@ -185,8 +183,6 @@ public:
 
     virtual QVariantMap toMap() const override;
     bool fromMap(const QVariantMap &map) override;
-
-    bool isActive() const override;
 
 signals:
     void stepInserted(int position);

--- a/src/project_manager/ros_run_steps_page.cpp
+++ b/src/project_manager/ros_run_steps_page.cpp
@@ -187,7 +187,7 @@ RunStepsWidgetData::~RunStepsWidgetData()
 }
 
 RunStepListWidget::RunStepListWidget(QWidget *parent) :
-    NamedWidget(parent)
+    NamedWidget(tr("Steps"), parent)
 {
 }
 
@@ -262,8 +262,6 @@ void RunStepListWidget::init(RunStepList *rsl)
     m_runStepsData.clear();
 
     m_runStepList = rsl;
-    //: %1 is the name returned by BuildStepList::displayName
-    setDisplayName(tr("%1 Steps").arg(m_runStepList->displayName()));
 
     for (int i = 0; i < rsl->count(); ++i) {
         addRunStep(i);
@@ -441,7 +439,7 @@ void RunStepListWidget::updateRunStepButtonsState()
 }
 
 RunStepsPage::RunStepsPage(ROSRunConfiguration *rc, Core::Id id) :
-    NamedWidget(),
+    NamedWidget(tr("ROS Run Steps")),
     m_id(id),
     m_widget(new RunStepListWidget(this))
 {
@@ -451,7 +449,6 @@ RunStepsPage::RunStepsPage(ROSRunConfiguration *rc, Core::Id id) :
     layout->addWidget(m_widget);
 
     m_widget->init(rc->stepList());
-    setDisplayName(tr("ROS Run Steps"));
 }
 
 } // namespace Internal


### PR DESCRIPTION
This PR contains the "4.12" commit subset, with one additional commit to fix the "Build Project" button when the active configuration is changed.

The usual features
- create workspace
- build workspace
- change active build configuration (`Debug`, `Release`, `Release with Debug Information`)
