### PR TITLE
clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,117 @@
+# .clang-format for Qt Creator
+#
+# This is for clang-format >= 5.0.
+#
+# The configuration below follows the Qt Creator Coding Rules [1] as closely as
+# possible. For documentation of the options, see [2].
+#
+# Use ../../tests/manual/clang-format-for-qtc/test.cpp for documenting problems
+# or testing changes.
+#
+# In case you update this configuration please also update the qtcStyle() in src\plugins\clangformat\clangformatutils.cpp
+#
+# [1] https://doc-snapshots.qt.io/qtcreator-extending/coding-style.html
+# [2] https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+#
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:    100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - forever # avoids { wrapped to next line
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex:           '^<Q.*'
+    Priority:        200
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+# Do not add QT_BEGIN_NAMESPACE/QT_END_NAMESPACE as this will indent lines in between.
+MacroBlockBegin: ""
+MacroBlockEnd:   ""
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 150
+PenaltyBreakBeforeFirstCallParameter: 300
+PenaltyBreakComment: 500
+PenaltyBreakFirstLessLess: 400
+PenaltyBreakString: 600
+PenaltyExcessCharacter: 50
+PenaltyReturnTypeOnItsOwnLine: 300
+PointerAlignment: Right
+ReflowComments:  false
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never

--- a/format_source_files.sh
+++ b/format_source_files.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+find . -regex './src/.*\(cpp\|h\)' -exec clang-format -style=file -i {} \;
+

--- a/src/project_manager/remove_directory_dialog.cpp
+++ b/src/project_manager/remove_directory_dialog.cpp
@@ -24,9 +24,9 @@
 
 using namespace Core;
 
-RemoveDirectoryDialog::RemoveDirectoryDialog(const QString &filePath, QWidget *parent) :
-    QDialog(parent),
-    m_ui(new Ui::RemoveDirectoryDialog)
+RemoveDirectoryDialog::RemoveDirectoryDialog(const QString &filePath, QWidget *parent)
+    : QDialog(parent)
+    , m_ui(new Ui::RemoveDirectoryDialog)
 {
     m_ui->setupUi(this);
     m_ui->directoryNameLabel->setText(QDir::toNativeSeparators(filePath));

--- a/src/project_manager/remove_directory_dialog.h
+++ b/src/project_manager/remove_directory_dialog.h
@@ -26,35 +26,36 @@
 #include <QDialog>
 
 namespace Core {
-namespace Ui { class RemoveDirectoryDialog;}
+namespace Ui {
+class RemoveDirectoryDialog;
+}
 
 /**
  * @brief This a remove directory dialog for deleting directories.
  */
 class CORE_EXPORT RemoveDirectoryDialog : public QDialog
 {
-  Q_OBJECT
+    Q_OBJECT
 public:
-  explicit RemoveDirectoryDialog(const QString &filePath, QWidget *parent = 0);
-  virtual ~RemoveDirectoryDialog();
+    explicit RemoveDirectoryDialog(const QString &filePath, QWidget *parent = 0);
+    virtual ~RemoveDirectoryDialog();
 
-  /**
+    /**
    * @brief Set whether to display the checkbox allowing the user to permanently delete the directory/
    * @param visible a bool.
    */
-  void setDeleteDirectoryVisible(bool visible);
+    void setDeleteDirectoryVisible(bool visible);
 
-  /**
+    /**
    * @brief Get the status of the permanent delete checkbox.
    * @return a bool.
    */
-  bool isDeleteDirectoryChecked() const;
+    bool isDeleteDirectoryChecked() const;
 
 private:
-  Ui::RemoveDirectoryDialog *m_ui; /**< The remove directory Ui */
-
+    Ui::RemoveDirectoryDialog *m_ui; /**< The remove directory Ui */
 };
 
-}
+} // namespace Core
 
 #endif // REMOVE_DIRECTORY_DIALOG_H

--- a/src/project_manager/ros_build_configuration.cpp
+++ b/src/project_manager/ros_build_configuration.cpp
@@ -92,58 +92,55 @@ void ROSBuildConfiguration::initialize(const ProjectExplorer::BuildInfo &info)
     Q_ASSERT(bs);
     Q_ASSERT(cs);
 
-    switch (extraInfo.buildSystem)
-    {
-        case ROSUtils::CatkinMake:
-        {
-            ROSCatkinMakeStep *makeStep = new ROSCatkinMakeStep(bs, ROS_CMS_ID);
-            bs->insertStep(0, makeStep);
-            makeStep->setBuildTarget(ROSCatkinMakeStep::BUILD);
+    switch (extraInfo.buildSystem) {
+    case ROSUtils::CatkinMake: {
+        ROSCatkinMakeStep *makeStep = new ROSCatkinMakeStep(bs, ROS_CMS_ID);
+        bs->insertStep(0, makeStep);
+        makeStep->setBuildTarget(ROSCatkinMakeStep::BUILD);
 
-            ROSCatkinMakeStep *cleanMakeStep = new ROSCatkinMakeStep(cs, ROS_CMS_ID);
-            cs->insertStep(0, cleanMakeStep);
-            cleanMakeStep->setBuildTarget(ROSCatkinMakeStep::CLEAN);
-            break;
-        }
-        case ROSUtils::CatkinTools:
-        {
-            ROSCatkinToolsStep *makeStep = new ROSCatkinToolsStep(bs, ROS_CTS_ID);
-            bs->insertStep(0, makeStep);
-            makeStep->setBuildTarget(ROSCatkinToolsStep::BUILD);
+        ROSCatkinMakeStep *cleanMakeStep = new ROSCatkinMakeStep(cs, ROS_CMS_ID);
+        cs->insertStep(0, cleanMakeStep);
+        cleanMakeStep->setBuildTarget(ROSCatkinMakeStep::CLEAN);
+        break;
+    }
+    case ROSUtils::CatkinTools: {
+        ROSCatkinToolsStep *makeStep = new ROSCatkinToolsStep(bs, ROS_CTS_ID);
+        bs->insertStep(0, makeStep);
+        makeStep->setBuildTarget(ROSCatkinToolsStep::BUILD);
 
-            ROSCatkinToolsStep *cleanMakeStep = new ROSCatkinToolsStep(cs, ROS_CTS_ID);
-            cs->insertStep(0, cleanMakeStep);
-            cleanMakeStep->setBuildTarget(ROSCatkinToolsStep::CLEAN);
-            break;
-        }
-        case ROSUtils::Colcon:
-        {
-            ROSColconStep *makeStep = new ROSColconStep(bs, ROS_COLCON_STEP_ID);
-            bs->insertStep(0, makeStep);
-            makeStep->setBuildTarget(ROSColconStep::BUILD);
+        ROSCatkinToolsStep *cleanMakeStep = new ROSCatkinToolsStep(cs, ROS_CTS_ID);
+        cs->insertStep(0, cleanMakeStep);
+        cleanMakeStep->setBuildTarget(ROSCatkinToolsStep::CLEAN);
+        break;
+    }
+    case ROSUtils::Colcon: {
+        ROSColconStep *makeStep = new ROSColconStep(bs, ROS_COLCON_STEP_ID);
+        bs->insertStep(0, makeStep);
+        makeStep->setBuildTarget(ROSColconStep::BUILD);
 
-            ROSColconStep *cleanMakeStep = new ROSColconStep(cs, ROS_COLCON_STEP_ID);
-            cs->insertStep(0, cleanMakeStep);
-            cleanMakeStep->setBuildTarget(ROSColconStep::CLEAN);
-            break;
-        }
+        ROSColconStep *cleanMakeStep = new ROSColconStep(cs, ROS_COLCON_STEP_ID);
+        cs->insertStep(0, cleanMakeStep);
+        cleanMakeStep->setBuildTarget(ROSColconStep::CLEAN);
+        break;
+    }
     }
 }
 
 QVariantMap ROSBuildConfiguration::toMap() const
 {
-  QVariantMap map(BuildConfiguration::toMap());
+    QVariantMap map(BuildConfiguration::toMap());
 
-  map.insert(QLatin1String(ROS_BC_BUILD_SYSTEM), (int)m_buildSystem);
-  map.insert(QLatin1String(ROS_BC_CMAKE_BUILD_TYPE), (int)m_cmakeBuildType);
-  return map;
+    map.insert(QLatin1String(ROS_BC_BUILD_SYSTEM), (int) m_buildSystem);
+    map.insert(QLatin1String(ROS_BC_CMAKE_BUILD_TYPE), (int) m_cmakeBuildType);
+    return map;
 }
 
 bool ROSBuildConfiguration::fromMap(const QVariantMap &map)
 {
-  m_buildSystem = (ROSUtils::BuildSystem)map.value(QLatin1String(ROS_BC_BUILD_SYSTEM)).toInt();
-  m_cmakeBuildType = (ROSUtils::BuildType)map.value(QLatin1String(ROS_BC_CMAKE_BUILD_TYPE)).toInt();
-  return BuildConfiguration::fromMap(map);
+    m_buildSystem = (ROSUtils::BuildSystem) map.value(QLatin1String(ROS_BC_BUILD_SYSTEM)).toInt();
+    m_cmakeBuildType = (ROSUtils::BuildType) map.value(QLatin1String(ROS_BC_CMAKE_BUILD_TYPE))
+                           .toInt();
+    return BuildConfiguration::fromMap(map);
 }
 
 ROSUtils::BuildSystem ROSBuildConfiguration::rosBuildSystem() const
@@ -182,7 +179,7 @@ void ROSBuildConfiguration::updateQtEnvironment(const Utils::Environment &env)
 {
     const Utils::NameValueItems diff = baseEnvironment().diff(env);
     if (!diff.isEmpty())
-      setUserEnvironmentChanges(diff);
+        setUserEnvironmentChanges(diff);
 }
 
 NamedWidget *ROSBuildConfiguration::createConfigWidget()
@@ -192,27 +189,29 @@ NamedWidget *ROSBuildConfiguration::createConfigWidget()
 
 QList<NamedWidget *> ROSBuildConfiguration::createSubConfigWidgets()
 {
-  return QList<NamedWidget *>() << new ROSBuildEnvironmentWidget(this);
+    return QList<NamedWidget *>() << new ROSBuildEnvironmentWidget(this);
 }
 
 /*!
   \class ROSBuildConfigurationFactory
 */
 
-ROSBuildConfigurationFactory::ROSBuildConfigurationFactory() :
-    BuildConfigurationFactory()
+ROSBuildConfigurationFactory::ROSBuildConfigurationFactory()
+    : BuildConfigurationFactory()
 {
     registerBuildConfiguration<ROSBuildConfiguration>(ROS_BC_ID);
 
     setSupportedProjectType(Constants::ROS_PROJECT_ID);
     setSupportedProjectMimeTypeName(Constants::ROS_MIME_TYPE);
 
-    setBuildGenerator(std::bind(&ROSBuildConfigurationFactory::availableBuilds, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+    setBuildGenerator(std::bind(&ROSBuildConfigurationFactory::availableBuilds,
+                                this,
+                                std::placeholders::_1,
+                                std::placeholders::_2,
+                                std::placeholders::_3));
 }
 
-ROSBuildConfigurationFactory::~ROSBuildConfigurationFactory()
-{
-}
+ROSBuildConfigurationFactory::~ROSBuildConfigurationFactory() {}
 
 QList<BuildInfo> ROSBuildConfigurationFactory::availableBuilds(const Kit *k,
                                                                const Utils::FilePath &projectPath,
@@ -227,15 +226,18 @@ QList<BuildInfo> ROSBuildConfigurationFactory::availableBuilds(const Kit *k,
     ROSUtils::parseQtCreatorWorkspaceFile(projectPath, projectFileContent);
 
     for (int type = ROSUtils::BuildTypeDebug; type <= ROSUtils::BuildTypeUserDefined; ++type) {
-      ProjectExplorer::BuildInfo info = createBuildInfo(k, projectFileContent.defaultBuildSystem, ROSUtils::BuildType(type));
-      result << info;
+        ProjectExplorer::BuildInfo info = createBuildInfo(k,
+                                                          projectFileContent.defaultBuildSystem,
+                                                          ROSUtils::BuildType(type));
+        result << info;
     }
 
     //TO DO: Should probably check if the directory that was selected was the workspace
     return result;
 }
 
-ProjectExplorer::BuildInfo ROSBuildConfigurationFactory::createBuildInfo(const Kit *k, const ROSUtils::BuildSystem &build_system, const ROSUtils::BuildType &type) const
+ProjectExplorer::BuildInfo ROSBuildConfigurationFactory::createBuildInfo(
+    const Kit *k, const ROSUtils::BuildSystem &build_system, const ROSUtils::BuildType &type) const
 {
     ProjectExplorer::BuildInfo info;
     info.kitId = k->id();
@@ -289,37 +291,43 @@ BuildConfiguration::BuildType ROSBuildConfiguration::buildType() const
 ////////////////////////////////////////////////////////////////////////////////////
 
 ROSBuildSettingsWidget::ROSBuildSettingsWidget(ROSBuildConfiguration *bc)
-    : NamedWidget(tr("ROS Manager")),
-      m_buildConfiguration(bc)
+    : NamedWidget(tr("ROS Manager"))
+    , m_buildConfiguration(bc)
 {
     m_ui = new Ui::ROSBuildConfiguration;
     m_ui->setupUi(this);
     m_ui->buildSystemComboBox->setCurrentIndex(bc->rosBuildSystem());
     m_ui->buildTypeComboBox->setCurrentIndex(bc->cmakeBuildType());
 
-    connect(m_ui->buildSystemComboBox, SIGNAL(currentIndexChanged(int)),
-            this, SLOT(buildSystemChanged(int)));
+    connect(m_ui->buildSystemComboBox,
+            SIGNAL(currentIndexChanged(int)),
+            this,
+            SLOT(buildSystemChanged(int)));
 
-    connect(m_ui->buildTypeComboBox, SIGNAL(currentIndexChanged(int)),
-            this, SLOT(buildTypeChanged(int)));
+    connect(m_ui->buildTypeComboBox,
+            SIGNAL(currentIndexChanged(int)),
+            this,
+            SLOT(buildTypeChanged(int)));
 
-    connect(m_ui->buildSourceWorkspaceButton, SIGNAL(clicked()),
-            this, SLOT(buildSourceWorkspaceButtonClicked()));
+    connect(m_ui->buildSourceWorkspaceButton,
+            SIGNAL(clicked()),
+            this,
+            SLOT(buildSourceWorkspaceButtonClicked()));
 }
 
 ROSBuildSettingsWidget::~ROSBuildSettingsWidget()
 {
-  delete m_ui;
+    delete m_ui;
 }
 
 void ROSBuildSettingsWidget::buildSystemChanged(int index)
 {
-    m_buildConfiguration->setBuildSystem(((ROSUtils::BuildSystem)index));
+    m_buildConfiguration->setBuildSystem(((ROSUtils::BuildSystem) index));
 }
 
 void ROSBuildSettingsWidget::buildTypeChanged(int index)
 {
-    m_buildConfiguration->setCMakeBuildType(((ROSUtils::BuildType)index));
+    m_buildConfiguration->setCMakeBuildType(((ROSUtils::BuildType) index));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -334,18 +342,26 @@ ROSBuildEnvironmentWidget::ROSBuildEnvironmentWidget(BuildConfiguration *bc)
     m_clearSystemEnvironmentCheckBox = new QCheckBox(this);
     m_clearSystemEnvironmentCheckBox->setText(tr("Clear system environment"));
 
-    m_buildEnvironmentWidget = new EnvironmentWidget(this, ProjectExplorer::EnvironmentWidget::TypeLocal, m_clearSystemEnvironmentCheckBox);
+    m_buildEnvironmentWidget = new EnvironmentWidget(this,
+                                                     ProjectExplorer::EnvironmentWidget::TypeLocal,
+                                                     m_clearSystemEnvironmentCheckBox);
     vbox->addWidget(m_buildEnvironmentWidget);
 
-    connect(m_buildEnvironmentWidget, SIGNAL(userChangesChanged()),
-            this, SLOT(environmentModelUserChangesChanged()));
-    connect(m_clearSystemEnvironmentCheckBox, SIGNAL(toggled(bool)),
-            this, SLOT(clearSystemEnvironmentCheckBoxClicked(bool)));
+    connect(m_buildEnvironmentWidget,
+            SIGNAL(userChangesChanged()),
+            this,
+            SLOT(environmentModelUserChangesChanged()));
+    connect(m_clearSystemEnvironmentCheckBox,
+            SIGNAL(toggled(bool)),
+            this,
+            SLOT(clearSystemEnvironmentCheckBoxClicked(bool)));
 
     m_buildConfiguration = bc;
 
-    connect(m_buildConfiguration, &BuildConfiguration::environmentChanged,
-            this, &ROSBuildEnvironmentWidget::environmentChanged);
+    connect(m_buildConfiguration,
+            &BuildConfiguration::environmentChanged,
+            this,
+            &ROSBuildEnvironmentWidget::environmentChanged);
 
     m_clearSystemEnvironmentCheckBox->setChecked(!m_buildConfiguration->useSystemEnvironment());
     m_buildEnvironmentWidget->setBaseEnvironment(m_buildConfiguration->baseEnvironment());
@@ -374,16 +390,17 @@ void ROSBuildEnvironmentWidget::environmentChanged()
 
 void ROSBuildSettingsWidget::buildSourceWorkspaceButtonClicked()
 {
-  ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(m_buildConfiguration->project()->projectDirectory(),
-                                                                     m_buildConfiguration->rosBuildSystem(),
-                                                                     m_buildConfiguration->project()->distribution());
+    ROSUtils::WorkspaceInfo workspaceInfo
+        = ROSUtils::getWorkspaceInfo(m_buildConfiguration->project()->projectDirectory(),
+                                     m_buildConfiguration->rosBuildSystem(),
+                                     m_buildConfiguration->project()->distribution());
 
-  Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo, m_buildConfiguration->environment()).toStringList());
+    Utils::Environment env(
+        ROSUtils::getWorkspaceEnvironment(workspaceInfo, m_buildConfiguration->environment())
+            .toStringList());
 
-  m_buildConfiguration->updateQtEnvironment(env);
+    m_buildConfiguration->updateQtEnvironment(env);
 }
 
 } // namespace Internal
-} // namespace GenericProjectManager
-
-
+} // namespace ROSProjectManager

--- a/src/project_manager/ros_build_configuration.h
+++ b/src/project_manager/ros_build_configuration.h
@@ -21,21 +21,21 @@
 #ifndef ROSBUILDCONFIGURATION_H
 #define ROSBUILDCONFIGURATION_H
 
-#include "ros_utils.h"
 #include "ros_project.h"
+#include "ros_utils.h"
 
 #include <projectexplorer/buildconfiguration.h>
-#include <projectexplorer/namedwidget.h>
 #include <projectexplorer/buildinfo.h>
-#include <projectexplorer/kit.h>
-#include <projectexplorer/target.h>
-#include <projectexplorer/project.h>
 #include <projectexplorer/environmentwidget.h>
+#include <projectexplorer/kit.h>
+#include <projectexplorer/namedwidget.h>
+#include <projectexplorer/project.h>
+#include <projectexplorer/target.h>
 #include <utils/environment.h>
 #include <utils/qtcassert.h>
 #include <QCheckBox>
-#include <QProcess>
 #include <QMenu>
+#include <QProcess>
 
 namespace Utils {
 class PathChooser;
@@ -47,7 +47,9 @@ namespace Internal {
 class ROSBuildConfigurationFactory;
 class ROSBuildSettingsWidget;
 class ROSExtraBuildInfo;
-namespace Ui { class ROSBuildConfiguration; }
+namespace Ui {
+class ROSBuildConfiguration;
+}
 
 class ROSBuildConfiguration : public ProjectExplorer::BuildConfiguration
 {
@@ -94,7 +96,6 @@ private:
     ROSBuildSystem *m_build_system;
     ROSUtils::BuildType m_cmakeBuildType;
     ProjectExplorer::NamedWidget *m_buildEnvironmentWidget;
-
 };
 
 class ROSBuildConfigurationFactory : public ProjectExplorer::BuildConfigurationFactory
@@ -108,7 +109,9 @@ public:
                                                       bool forSetup) const;
 
 private:
-    ProjectExplorer::BuildInfo createBuildInfo(const ProjectExplorer::Kit *k, const ROSUtils::BuildSystem &build_system, const ROSUtils::BuildType &type) const;
+    ProjectExplorer::BuildInfo createBuildInfo(const ProjectExplorer::Kit *k,
+                                               const ROSUtils::BuildSystem &build_system,
+                                               const ROSUtils::BuildType &type) const;
 };
 
 class ROSBuildSettingsWidget : public ProjectExplorer::NamedWidget
@@ -131,20 +134,20 @@ private:
 
 class ROSBuildEnvironmentWidget : public ProjectExplorer::NamedWidget
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  ROSBuildEnvironmentWidget(ProjectExplorer::BuildConfiguration *bc);
+    ROSBuildEnvironmentWidget(ProjectExplorer::BuildConfiguration *bc);
 
 private slots:
-  void environmentModelUserChangesChanged();
-  void clearSystemEnvironmentCheckBoxClicked(bool checked);
-  void environmentChanged();
+    void environmentModelUserChangesChanged();
+    void clearSystemEnvironmentCheckBoxClicked(bool checked);
+    void environmentChanged();
 
 protected:
-  ProjectExplorer::EnvironmentWidget *m_buildEnvironmentWidget;
-  QCheckBox *m_clearSystemEnvironmentCheckBox;
-  ProjectExplorer::BuildConfiguration *m_buildConfiguration;
+    ProjectExplorer::EnvironmentWidget *m_buildEnvironmentWidget;
+    QCheckBox *m_clearSystemEnvironmentCheckBox;
+    ProjectExplorer::BuildConfiguration *m_buildConfiguration;
 };
 
 } // namespace Internal

--- a/src/project_manager/ros_build_system.cpp
+++ b/src/project_manager/ros_build_system.cpp
@@ -11,9 +11,11 @@ namespace Internal {
 // --------------------------------------------------------------------
 
 ROSBuildSystem::ROSBuildSystem(ROSBuildConfiguration *bc)
-    : BuildSystem((BuildConfiguration*)bc)
+    : BuildSystem((BuildConfiguration *) bc)
 {
-    connect(((BuildConfiguration*)bc)->project(), &Project::activeTargetChanged, this, [this]() { triggerParsing(); });
+    connect(((BuildConfiguration *) bc)->project(), &Project::activeTargetChanged, this, [this]() {
+        triggerParsing();
+    });
 }
 
 void ROSBuildSystem::triggerParsing()
@@ -21,12 +23,16 @@ void ROSBuildSystem::triggerParsing()
     guardParsingRun().markAsSuccess();
 }
 
-bool ROSBuildSystem::addFiles(ProjectExplorer::Node *context, const QStringList &filePaths, QStringList *notAdded)
+bool ROSBuildSystem::addFiles(ProjectExplorer::Node *context,
+                              const QStringList &filePaths,
+                              QStringList *notAdded)
 {
     return true;
 }
 
-ProjectExplorer::RemovedFilesFromProject ROSBuildSystem::removeFiles(ProjectExplorer::Node *context, const QStringList &filePaths, QStringList *notRemoved)
+ProjectExplorer::RemovedFilesFromProject ROSBuildSystem::removeFiles(ProjectExplorer::Node *context,
+                                                                     const QStringList &filePaths,
+                                                                     QStringList *notRemoved)
 {
     return ProjectExplorer::RemovedFilesFromProject::Ok;
 }
@@ -36,12 +42,16 @@ bool ROSBuildSystem::deleteFiles(ProjectExplorer::Node *context, const QStringLi
     return true;
 }
 
-bool ROSBuildSystem::canRenameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath)
+bool ROSBuildSystem::canRenameFile(ProjectExplorer::Node *context,
+                                   const QString &filePath,
+                                   const QString &newFilePath)
 {
     return true;
 }
 
-bool ROSBuildSystem::renameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath)
+bool ROSBuildSystem::renameFile(ProjectExplorer::Node *context,
+                                const QString &filePath,
+                                const QString &newFilePath)
 {
     return true;
 }
@@ -51,7 +61,9 @@ bool ROSBuildSystem::addDependencies(ProjectExplorer::Node *context, const QStri
     return true;
 }
 
-bool ROSBuildSystem::supportsAction(ProjectExplorer::Node *context, ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const
+bool ROSBuildSystem::supportsAction(ProjectExplorer::Node *context,
+                                    ProjectExplorer::ProjectAction action,
+                                    const ProjectExplorer::Node *node) const
 {
     static const std::set<ProjectAction> possible_actions = {
         ProjectAction::AddNewFile,

--- a/src/project_manager/ros_build_system.h
+++ b/src/project_manager/ros_build_system.h
@@ -21,14 +21,25 @@ public:
 
     void triggerParsing() final;
 
-    virtual bool addFiles(ProjectExplorer::Node *context, const QStringList &filePaths, QStringList *notAdded = nullptr) final;
-    virtual ProjectExplorer::RemovedFilesFromProject removeFiles(ProjectExplorer::Node *context, const QStringList &filePaths,
-                                                                 QStringList *notRemoved = nullptr) final;
+    virtual bool addFiles(ProjectExplorer::Node *context,
+                          const QStringList &filePaths,
+                          QStringList *notAdded = nullptr) final;
+    virtual ProjectExplorer::RemovedFilesFromProject removeFiles(
+        ProjectExplorer::Node *context,
+        const QStringList &filePaths,
+        QStringList *notRemoved = nullptr) final;
     virtual bool deleteFiles(ProjectExplorer::Node *context, const QStringList &filePaths) final;
-    virtual bool canRenameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath) final;
-    virtual bool renameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath) final;
-    virtual bool addDependencies(ProjectExplorer::Node *context, const QStringList &dependencies) final;
-    virtual bool supportsAction(ProjectExplorer::Node *context, ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const final;
+    virtual bool canRenameFile(ProjectExplorer::Node *context,
+                               const QString &filePath,
+                               const QString &newFilePath) final;
+    virtual bool renameFile(ProjectExplorer::Node *context,
+                            const QString &filePath,
+                            const QString &newFilePath) final;
+    virtual bool addDependencies(ProjectExplorer::Node *context,
+                                 const QStringList &dependencies) final;
+    virtual bool supportsAction(ProjectExplorer::Node *context,
+                                ProjectExplorer::ProjectAction action,
+                                const ProjectExplorer::Node *node) const final;
 };
 
 } // namespace Internal

--- a/src/project_manager/ros_catkin_make_step.h
+++ b/src/project_manager/ros_catkin_make_step.h
@@ -21,8 +21,8 @@
 #ifndef ROSCATKINMAKESTEP_H
 #define ROSCATKINMAKESTEP_H
 
-#include <projectexplorer/abstractprocessstep.h>
 #include "ros_build_configuration.h"
+#include <projectexplorer/abstractprocessstep.h>
 
 QT_BEGIN_NAMESPACE
 class QListWidgetItem;
@@ -33,7 +33,9 @@ namespace Internal {
 
 class ROSCatkinMakeStepWidget;
 class ROSCatkinMakeStepFactory;
-namespace Ui { class ROSCatkinMakeStep; }
+namespace Ui {
+class ROSCatkinMakeStep;
+}
 
 static const char ROS_CMS_ID[] = "ROSProjectManager.ROSCatkinMakeStep";
 
@@ -45,7 +47,7 @@ class ROSCatkinMakeStep : public ProjectExplorer::AbstractProcessStep
     friend class ROSCatkinMakeStepFactory;
 
 public:
-    enum BuildTargets {BUILD = 0, CLEAN = 1};
+    enum BuildTargets { BUILD = 0, CLEAN = 1 };
 
     ROSCatkinMakeStep(ProjectExplorer::BuildStepList *parent, Utils::Id id);
     ~ROSCatkinMakeStep() override;

--- a/src/project_manager/ros_catkin_test_results_step.cpp
+++ b/src/project_manager/ros_catkin_test_results_step.cpp
@@ -20,40 +20,42 @@
  */
 
 #include "ros_catkin_test_results_step.h"
-#include "ros_utils.h"
 #include "ros_build_configuration.h"
+#include "ros_utils.h"
 
 namespace ROSProjectManager {
 namespace Internal {
 
-ROSCatkinTestResultsStep::ROSCatkinTestResultsStep(RunStepList *rsl) : ROSGenericRunStep(rsl, Constants::ROS_CATKIN_TEST_RESULTS_ID)
+ROSCatkinTestResultsStep::ROSCatkinTestResultsStep(RunStepList *rsl)
+    : ROSGenericRunStep(rsl, Constants::ROS_CATKIN_TEST_RESULTS_ID)
 {
-  ctor();
+    ctor();
 }
 
-ROSCatkinTestResultsStep::ROSCatkinTestResultsStep(RunStepList *rsl, Utils::Id id) : ROSGenericRunStep(rsl, id)
+ROSCatkinTestResultsStep::ROSCatkinTestResultsStep(RunStepList *rsl, Utils::Id id)
+    : ROSGenericRunStep(rsl, id)
 {
-  ctor();
+    ctor();
 }
 
 void ROSCatkinTestResultsStep::ctor()
 {
-  setCommand("catkin_test_results");
+    setCommand("catkin_test_results");
 }
 
 RunStepConfigWidget *ROSCatkinTestResultsStep::createConfigWidget()
 {
-  return new ROSGenericRunStepConfigWidget(this, false, true, false);
+    return new ROSGenericRunStepConfigWidget(this, false, true, false);
 }
 
-ROSCatkinTestResultsStepFactory::ROSCatkinTestResultsStepFactory() :
-    RunStepFactory()
+ROSCatkinTestResultsStepFactory::ROSCatkinTestResultsStepFactory()
+    : RunStepFactory()
 {
-  registerStep<ROSCatkinTestResultsStep>(Constants::ROS_CATKIN_TEST_RESULTS_ID);
-  setDisplayName("ROS Catkin Test Results Step");
-  setFlags(RunStepInfo::Flags::UniqueStep);
-  setSupportedProjectType(Constants::ROS_PROJECT_ID);
-  setSupportedStepList(Constants::ROS_RUN_STEP_LIST_ID);
+    registerStep<ROSCatkinTestResultsStep>(Constants::ROS_CATKIN_TEST_RESULTS_ID);
+    setDisplayName("ROS Catkin Test Results Step");
+    setFlags(RunStepInfo::Flags::UniqueStep);
+    setSupportedProjectType(Constants::ROS_PROJECT_ID);
+    setSupportedStepList(Constants::ROS_RUN_STEP_LIST_ID);
 }
 
 } // namespace Internal

--- a/src/project_manager/ros_catkin_test_results_step.h
+++ b/src/project_manager/ros_catkin_test_results_step.h
@@ -26,23 +26,24 @@
 namespace ROSProjectManager {
 namespace Internal {
 
-namespace Ui { class ROSGenericStep; }
+namespace Ui {
+class ROSGenericStep;
+}
 
 class ROSCatkinTestResultsStep : public ROSGenericRunStep
 {
-  Q_OBJECT
-  friend class ROSCatkinTestResultsStepFactory;
+    Q_OBJECT
+    friend class ROSCatkinTestResultsStepFactory;
 
 public:
-  ROSCatkinTestResultsStep(RunStepList *rsl);
+    ROSCatkinTestResultsStep(RunStepList *rsl);
 
 protected:
-  ROSCatkinTestResultsStep(RunStepList *rsl, Utils::Id id);
+    ROSCatkinTestResultsStep(RunStepList *rsl, Utils::Id id);
 
-  void ctor();
+    void ctor();
 
-  RunStepConfigWidget *createConfigWidget() override;
-
+    RunStepConfigWidget *createConfigWidget() override;
 };
 
 class ROSCatkinTestResultsStepFactory : public RunStepFactory
@@ -51,7 +52,7 @@ public:
     ROSCatkinTestResultsStepFactory();
 };
 
-} // Internal
-} // ROSProjectManager
+} // namespace Internal
+} // namespace ROSProjectManager
 
 #endif // ROS_CATKIN_TEST_RESULTS_STEP_H

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -19,13 +19,15 @@
  * limitations under the License.
  */
 #include "ros_catkin_tools_step.h"
-#include "ros_project_constants.h"
 #include "ros_project.h"
-#include "ui_ros_catkin_tools_step.h"
-#include "ui_ros_catkin_tools_list_editor.h"
+#include "ros_project_constants.h"
 #include "ui_ros_catkin_tools_config_editor.h"
+#include "ui_ros_catkin_tools_list_editor.h"
+#include "ui_ros_catkin_tools_step.h"
 
 #include <boost/algorithm/string/join.hpp>
+#include <cmakeprojectmanager/cmakeparser.h>
+#include <coreplugin/messagemanager.h>
 #include <extensionsystem/pluginmanager.h>
 #include <projectexplorer/buildsteplist.h>
 #include <projectexplorer/gnumakeparser.h>
@@ -34,14 +36,12 @@
 #include <projectexplorer/projectexplorer.h>
 #include <projectexplorer/projectexplorerconstants.h>
 #include <projectexplorer/toolchain.h>
-#include <qtsupport/qtkitinformation.h>
-#include <qtsupport/qtparser.h>
-#include <utils/stringutils.h>
 #include <utils/qtcassert.h>
 #include <utils/qtcprocess.h>
-#include <cmakeprojectmanager/cmakeparser.h>
+#include <utils/stringutils.h>
 #include <utils/variablechooser.h>
-#include <coreplugin/messagemanager.h>
+#include <qtsupport/qtkitinformation.h>
+#include <qtsupport/qtparser.h>
 
 #include <fstream>
 #include <QDir>
@@ -52,28 +52,33 @@ using namespace ProjectExplorer;
 namespace ROSProjectManager {
 namespace Internal {
 
-const char ROS_CTS_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("ROSProjectManager::Internal::ROSCatkinToolsStep",
-                                                     "CatkinTools Step");
+const char ROS_CTS_DISPLAY_NAME[]
+    = QT_TRANSLATE_NOOP("ROSProjectManager::Internal::ROSCatkinToolsStep", "CatkinTools Step");
 const char ROS_CTS_TARGET_KEY[] = "ROSProjectManager.ROSCatkinToolsStep.Target";
 const char ROS_CTS_ACTIVE_PROFILE_KEY[] = "ROSProjectManager.ROSCatkinToolsStep.ActiveProfile";
-const char ROS_CTS_CATKIN_TOOLS_ARGUMENTS_KEY[] = "ROSProjectManager.ROSCatkinToolsStep.CatkinToolsArguments";
-const char ROS_CTS_CATKIN_TOOLS_WORKING_DIR_KEY[] = "ROSProjectManager.ROSCatkinToolsStep.CatkinToolsWorkingDir";
-const char ROS_CTS_CATKIN_MAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSCatkinToolsStep.CatkinMakeArguments";
+const char ROS_CTS_CATKIN_TOOLS_ARGUMENTS_KEY[]
+    = "ROSProjectManager.ROSCatkinToolsStep.CatkinToolsArguments";
+const char ROS_CTS_CATKIN_TOOLS_WORKING_DIR_KEY[]
+    = "ROSProjectManager.ROSCatkinToolsStep.CatkinToolsWorkingDir";
+const char ROS_CTS_CATKIN_MAKE_ARGUMENTS_KEY[]
+    = "ROSProjectManager.ROSCatkinToolsStep.CatkinMakeArguments";
 const char ROS_CTS_CMAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSCatkinToolsStep.CMakeArguments";
 const char ROS_CTS_MAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSCatkinToolsStep.MakeArguments";
 
-ROSCatkinToolsStep::ROSCatkinToolsStep(BuildStepList *parent, const Utils::Id id) :
-    AbstractProcessStep(parent, id)
+ROSCatkinToolsStep::ROSCatkinToolsStep(BuildStepList *parent, const Utils::Id id)
+    : AbstractProcessStep(parent, id)
 {
     m_catkinToolsWorkingDir = Constants::ROS_DEFAULT_WORKING_DIR;
 
-    setDefaultDisplayName(QCoreApplication::translate("ROSProjectManager::Internal::ROSCatkinToolsStep",
-                                                      ROS_CTS_DISPLAY_NAME));
+    setDefaultDisplayName(
+        QCoreApplication::translate("ROSProjectManager::Internal::ROSCatkinToolsStep",
+                                    ROS_CTS_DISPLAY_NAME));
 
     if (m_activeProfile.isEmpty())
         m_activeProfile = "default";
 
-    m_percentProgress = QRegExp(QLatin1String(".+\\[(\\d+)/(\\d+) complete\\]")); // Example: [0/24 complete]
+    m_percentProgress = QRegExp(
+        QLatin1String(".+\\[(\\d+)/(\\d+) complete\\]")); // Example: [0/24 complete]
 
     ROSBuildConfiguration *bc = rosBuildConfiguration();
     if (bc->rosBuildSystem() != ROSUtils::CatkinTools)
@@ -90,9 +95,7 @@ ROSBuildConfiguration *ROSCatkinToolsStep::targetsActiveBuildConfiguration() con
     return static_cast<ROSBuildConfiguration *>(target()->activeBuildConfiguration());
 }
 
-ROSCatkinToolsStep::~ROSCatkinToolsStep()
-{
-}
+ROSCatkinToolsStep::~ROSCatkinToolsStep() {}
 
 bool ROSCatkinToolsStep::init()
 {
@@ -100,7 +103,8 @@ bool ROSCatkinToolsStep::init()
     if (!bc)
         bc = targetsActiveBuildConfiguration();
 
-    ToolChain *tc = ToolChainKitAspect::toolChain(target()->kit(), ProjectExplorer::Constants::CXX_LANGUAGE_ID);
+    ToolChain *tc = ToolChainKitAspect::toolChain(target()->kit(),
+                                                  ProjectExplorer::Constants::CXX_LANGUAGE_ID);
 
     if (!tc)
         emit addTask(Task::compilerMissingTask());
@@ -112,8 +116,12 @@ bool ROSCatkinToolsStep::init()
 
     // Set Catkin Tools Active Profile
     ROSUtils::setCatkinToolsActiveProfile(bc->project()->projectDirectory(), activeProfile());
-    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->rosBuildSystem(), bc->project()->distribution());
-    Utils::Environment env(ROSUtils::getWorkspaceEnvironment(workspaceInfo, bc->environment()).toStringList());
+    ROSUtils::WorkspaceInfo workspaceInfo
+        = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(),
+                                     bc->rosBuildSystem(),
+                                     bc->project()->distribution());
+    Utils::Environment env(
+        ROSUtils::getWorkspaceEnvironment(workspaceInfo, bc->environment()).toStringList());
 
     bc->updateQtEnvironment(env); // TODO: Not sure if this is required here
 
@@ -166,13 +174,14 @@ QVariantMap ROSCatkinToolsStep::toMap() const
 
 bool ROSCatkinToolsStep::fromMap(const QVariantMap &map)
 {
-    m_target = (BuildTargets)map.value(QLatin1String(ROS_CTS_TARGET_KEY)).toInt();
+    m_target = (BuildTargets) map.value(QLatin1String(ROS_CTS_TARGET_KEY)).toInt();
     m_activeProfile = map.value(QLatin1String(ROS_CTS_ACTIVE_PROFILE_KEY)).toString();
     m_catkinToolsArguments = map.value(QLatin1String(ROS_CTS_CATKIN_TOOLS_ARGUMENTS_KEY)).toString();
     m_catkinMakeArguments = map.value(QLatin1String(ROS_CTS_CATKIN_MAKE_ARGUMENTS_KEY)).toString();
     m_cmakeArguments = map.value(QLatin1String(ROS_CTS_CMAKE_ARGUMENTS_KEY)).toString();
     m_makeArguments = map.value(QLatin1String(ROS_CTS_MAKE_ARGUMENTS_KEY)).toString();
-    m_catkinToolsWorkingDir = map.value(QLatin1String(ROS_CTS_CATKIN_TOOLS_WORKING_DIR_KEY)).toString();
+    m_catkinToolsWorkingDir = map.value(QLatin1String(ROS_CTS_CATKIN_TOOLS_WORKING_DIR_KEY))
+                                  .toString();
 
     if (m_catkinToolsWorkingDir.isEmpty())
         m_catkinToolsWorkingDir = Constants::ROS_DEFAULT_WORKING_DIR;
@@ -184,19 +193,23 @@ QString ROSCatkinToolsStep::allArguments(ROSUtils::BuildType buildType, bool inc
 {
     QString args;
 
-    switch(m_target) {
+    switch (m_target) {
     case BUILD:
         Utils::QtcProcess::addArgs(&args, QLatin1String("build"));
         Utils::QtcProcess::addArgs(&args, m_catkinToolsArguments);
 
         if (!m_catkinMakeArguments.isEmpty())
-            Utils::QtcProcess::addArgs(&args, QString("--catkin-make-args %1").arg(m_catkinMakeArguments));
+            Utils::QtcProcess::addArgs(&args,
+                                       QString("--catkin-make-args %1").arg(m_catkinMakeArguments));
 
         if (includeDefault)
-            Utils::QtcProcess::addArgs(&args, QString("--cmake-args -G \"CodeBlocks - Unix Makefiles\" %1 %2").arg(ROSUtils::getCMakeBuildTypeArgument(buildType), m_cmakeArguments));
-        else
-            if (!m_cmakeArguments.isEmpty())
-                Utils::QtcProcess::addArgs(&args, QString("--cmake-args %1").arg(m_cmakeArguments));
+            Utils::QtcProcess::addArgs(&args,
+                                       QString(
+                                           "--cmake-args -G \"CodeBlocks - Unix Makefiles\" %1 %2")
+                                           .arg(ROSUtils::getCMakeBuildTypeArgument(buildType),
+                                                m_cmakeArguments));
+        else if (!m_cmakeArguments.isEmpty())
+            Utils::QtcProcess::addArgs(&args, QString("--cmake-args %1").arg(m_cmakeArguments));
 
         break;
     case CLEAN:
@@ -205,7 +218,8 @@ QString ROSCatkinToolsStep::allArguments(ROSUtils::BuildType buildType, bool inc
         Utils::QtcProcess::addArgs(&args, m_catkinToolsArguments);
 
         if (!m_catkinMakeArguments.isEmpty())
-            Utils::QtcProcess::addArgs(&args, QString("--catkin-make-args %1").arg(m_catkinMakeArguments));
+            Utils::QtcProcess::addArgs(&args,
+                                       QString("--catkin-make-args %1").arg(m_catkinMakeArguments));
 
         if (!m_cmakeArguments.isEmpty())
             Utils::QtcProcess::addArgs(&args, QString("--cmake-args %1").arg(m_cmakeArguments));
@@ -228,12 +242,13 @@ Utils::CommandLine ROSCatkinToolsStep::makeCommand(const QString &args) const
 void ROSCatkinToolsStep::stdOutput(const QString &line)
 {
     AbstractProcessStep::stdOutput(line);
-    if (m_percentProgress.indexIn(line, 0) != -1)
-    {
+    if (m_percentProgress.indexIn(line, 0) != -1) {
         bool ok = false;
-        int percent = (m_percentProgress.cap(1).toDouble(&ok)/m_percentProgress.cap(2).toDouble(&ok)) * 100.0;
+        int percent = (m_percentProgress.cap(1).toDouble(&ok)
+                       / m_percentProgress.cap(2).toDouble(&ok))
+                      * 100.0;
         if (ok)
-          emit progress(percent, QString());
+            emit progress(percent, QString());
     }
 }
 
@@ -275,7 +290,8 @@ ROSCatkinToolsStepWidget::ROSCatkinToolsStepWidget(ROSCatkinToolsStep *makeStep)
     m_ui->catkinToolsWorkingDirWidget->setPath(m_makeStep->m_catkinToolsWorkingDir);
     m_ui->catkinToolsWorkingDirWidget->setHistoryCompleter(QLatin1String("Qt.WorkingDir.History"));
     m_ui->catkinToolsWorkingDirWidget->setExpectedKind(Utils::PathChooser::Directory);
-    m_ui->catkinToolsWorkingDirWidget->setFileName(makeStep->rosBuildConfiguration()->project()->projectDirectory());
+    m_ui->catkinToolsWorkingDirWidget->setFileName(
+        makeStep->rosBuildConfiguration()->project()->projectDirectory());
 
     setProfile(m_makeStep->m_activeProfile);
 
@@ -283,62 +299,86 @@ ROSCatkinToolsStepWidget::ROSCatkinToolsStepWidget(ROSCatkinToolsStep *makeStep)
     m_ui->addPushButton->setMenu(m_addButtonMenu);
 
     QAction *cloneAction = m_addButtonMenu->addAction(tr("&Clone Selected"));
-    connect(cloneAction, &QAction::triggered,
-            this, [this]() { cloneProfile(m_makeStep->activeProfile()); });
+    connect(cloneAction, &QAction::triggered, this, [this]() {
+        cloneProfile(m_makeStep->activeProfile());
+    });
 
     QAction *newAction = m_addButtonMenu->addAction(tr("&New Profile"));
-    connect(newAction, &QAction::triggered,
-            this, &ROSCatkinToolsStepWidget::newProfile);
+    connect(newAction, &QAction::triggered, this, &ROSCatkinToolsStepWidget::newProfile);
 
     m_profileMenu = new QMenu(this);
     m_ui->profilePushButton->setMenu(m_profileMenu);
 
-    connect(m_profileMenu, &QMenu::aboutToShow,
-            this, &ROSCatkinToolsStepWidget::updateProfileButtonMenu);
+    connect(m_profileMenu,
+            &QMenu::aboutToShow,
+            this,
+            &ROSCatkinToolsStepWidget::updateProfileButtonMenu);
 
     updateDetails();
 
-    connect(m_ui->removePushButton, &QAbstractButton::clicked,
-            this, [this]() { removeProfile(m_makeStep->activeProfile()); });
+    connect(m_ui->removePushButton, &QAbstractButton::clicked, this, [this]() {
+        removeProfile(m_makeStep->activeProfile());
+    });
 
-    connect(m_ui->renamePushButton, &QAbstractButton::clicked,
-            this, [this]() { renameProfile(m_makeStep->activeProfile()); });
+    connect(m_ui->renamePushButton, &QAbstractButton::clicked, this, [this]() {
+        renameProfile(m_makeStep->activeProfile());
+    });
 
-    connect(m_ui->editPushButton, &QAbstractButton::clicked,
-            this, [this]() { editProfile(m_makeStep->activeProfile()); });
+    connect(m_ui->editPushButton, &QAbstractButton::clicked, this, [this]() {
+        editProfile(m_makeStep->activeProfile());
+    });
 
-    connect(m_ui->catkinToolsArgumentsLineEdit, &QLineEdit::textEdited,
-            this, &ROSCatkinToolsStepWidget::updateDetails);
+    connect(m_ui->catkinToolsArgumentsLineEdit,
+            &QLineEdit::textEdited,
+            this,
+            &ROSCatkinToolsStepWidget::updateDetails);
 
-    connect(m_ui->catkinMakeArgumentsLineEdit, &QLineEdit::textEdited,
-            this, &ROSCatkinToolsStepWidget::updateDetails);
+    connect(m_ui->catkinMakeArgumentsLineEdit,
+            &QLineEdit::textEdited,
+            this,
+            &ROSCatkinToolsStepWidget::updateDetails);
 
-    connect(m_ui->cmakeArgumentsLineEdit, &QLineEdit::textEdited,
-            this, &ROSCatkinToolsStepWidget::updateDetails);
+    connect(m_ui->cmakeArgumentsLineEdit,
+            &QLineEdit::textEdited,
+            this,
+            &ROSCatkinToolsStepWidget::updateDetails);
 
-    connect(m_ui->makeArgumentsLineEdit, &QLineEdit::textEdited,
-            this, &ROSCatkinToolsStepWidget::updateDetails);
+    connect(m_ui->makeArgumentsLineEdit,
+            &QLineEdit::textEdited,
+            this,
+            &ROSCatkinToolsStepWidget::updateDetails);
 
-    connect(m_ui->catkinToolsWorkingDirWidget, &Utils::PathChooser::rawPathChanged,
-            this, &ROSCatkinToolsStepWidget::updateDetails);
+    connect(m_ui->catkinToolsWorkingDirWidget,
+            &Utils::PathChooser::rawPathChanged,
+            this,
+            &ROSCatkinToolsStepWidget::updateDetails);
 
-    connect(m_makeStep, SIGNAL(enabledChanged()),
-            this, SLOT(enabledChanged()));
+    connect(m_makeStep, SIGNAL(enabledChanged()), this, SLOT(enabledChanged()));
 
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
-    connect(bc, SIGNAL(buildSystemChanged(ROSUtils::BuildSystem)),
-            this, SLOT(updateBuildSystem(ROSUtils::BuildSystem)));
+    connect(bc,
+            SIGNAL(buildSystemChanged(ROSUtils::BuildSystem)),
+            this,
+            SLOT(updateBuildSystem(ROSUtils::BuildSystem)));
 
-    connect(bc, &ROSBuildConfiguration::cmakeBuildTypeChanged,
-            this, &ROSCatkinToolsStepWidget::updateDetails);
+    connect(bc,
+            &ROSBuildConfiguration::cmakeBuildTypeChanged,
+            this,
+            &ROSCatkinToolsStepWidget::updateDetails);
 
-    connect(bc, &ROSBuildConfiguration::environmentChanged,
-            this, &ROSCatkinToolsStepWidget::updateDetails);
+    connect(bc,
+            &ROSBuildConfiguration::environmentChanged,
+            this,
+            &ROSCatkinToolsStepWidget::updateDetails);
 
-    connect(ProjectExplorerPlugin::instance(), SIGNAL(settingsChanged()),
-            this, SLOT(updateDetails()));
+    connect(ProjectExplorerPlugin::instance(),
+            SIGNAL(settingsChanged()),
+            this,
+            SLOT(updateDetails()));
 
-    Utils::VariableChooser::addSupportForChildWidgets(this, makeStep->rosBuildConfiguration()->macroExpander());
+    Utils::VariableChooser::addSupportForChildWidgets(this,
+                                                      makeStep->rosBuildConfiguration()
+                                                          ->macroExpander());
 }
 
 ROSCatkinToolsStepWidget::~ROSCatkinToolsStepWidget()
@@ -360,7 +400,10 @@ void ROSCatkinToolsStepWidget::updateDetails()
     m_makeStep->m_catkinToolsWorkingDir = m_ui->catkinToolsWorkingDirWidget->rawPath();
 
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
-    ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->rosBuildSystem(), bc->project()->distribution());
+    ROSUtils::WorkspaceInfo workspaceInfo
+        = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(),
+                                     bc->rosBuildSystem(),
+                                     bc->project()->distribution());
 
     m_ui->catkinToolsWorkingDirWidget->setEnvironment(bc->environment());
 
@@ -368,7 +411,8 @@ void ROSCatkinToolsStepWidget::updateDetails()
     param.setMacroExpander(bc->macroExpander());
     param.setEnvironment(bc->environment());
     param.setWorkingDirectory(Utils::FilePath::fromString(m_makeStep->m_catkinToolsWorkingDir));
-    param.setCommandLine(m_makeStep->makeCommand(m_makeStep->allArguments(bc->cmakeBuildType(), false)));
+    param.setCommandLine(
+        m_makeStep->makeCommand(m_makeStep->allArguments(bc->cmakeBuildType(), false)));
     m_summaryText = param.summary(displayName());
 }
 
@@ -380,7 +424,7 @@ void ROSCatkinToolsStepWidget::updateBuildSystem(const ROSUtils::BuildSystem &bu
 void ROSCatkinToolsStepWidget::enabledChanged()
 {
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
-    if(m_makeStep->enabled() && (bc->rosBuildSystem() != ROSUtils::CatkinTools))
+    if (m_makeStep->enabled() && (bc->rosBuildSystem() != ROSUtils::CatkinTools))
         m_makeStep->setEnabled(false);
 }
 
@@ -393,9 +437,9 @@ void ROSCatkinToolsStepWidget::updateProfileButtonMenu()
 {
     m_profileMenu->clear();
 
-    QStringList profileNames = ROSUtils::getCatkinToolsProfileNames(m_makeStep->rosBuildConfiguration()->project()->projectDirectory());
-    for(const QString& profile : profileNames)
-    {
+    QStringList profileNames = ROSUtils::getCatkinToolsProfileNames(
+        m_makeStep->rosBuildConfiguration()->project()->projectDirectory());
+    for (const QString &profile : profileNames) {
         QAction *action = m_profileMenu->addAction(profile);
         connect(action, &QAction::triggered, this, [this, profile] { setProfile(profile); });
     }
@@ -410,17 +454,20 @@ void ROSCatkinToolsStepWidget::setProfile(const QString profileName)
 void ROSCatkinToolsStepWidget::cloneProfile(const QString profileName)
 {
     QString name = uniqueName(profileName, false);
-    ROSUtils::cloneCatkinToolsProfile(m_makeStep->rosBuildConfiguration()->project()->projectDirectory(), profileName, name);
+    ROSUtils::cloneCatkinToolsProfile(
+        m_makeStep->rosBuildConfiguration()->project()->projectDirectory(), profileName, name);
     setProfile(name);
 }
 
 void ROSCatkinToolsStepWidget::newProfile()
 {
     bool ok;
-    QString name = QInputDialog::getText(this, tr("New Profile..."),
+    QString name = QInputDialog::getText(this,
+                                         tr("New Profile..."),
                                          tr("Pofile Name:"),
                                          QLineEdit::Normal,
-                                         QLatin1String("default"), &ok);
+                                         QLatin1String("default"),
+                                         &ok);
     if (!ok)
         return;
 
@@ -428,7 +475,8 @@ void ROSCatkinToolsStepWidget::newProfile()
     if (name.isEmpty())
         return;
 
-    if (!ROSUtils::createCatkinToolsProfile(m_makeStep->rosBuildConfiguration()->project()->projectDirectory(), name, false))
+    if (!ROSUtils::createCatkinToolsProfile(
+            m_makeStep->rosBuildConfiguration()->project()->projectDirectory(), name, false))
         return;
 
     setProfile(name);
@@ -437,11 +485,12 @@ void ROSCatkinToolsStepWidget::newProfile()
 void ROSCatkinToolsStepWidget::renameProfile(const QString profileName)
 {
     bool ok;
-    QString name = QInputDialog::getText(this, tr("Rename..."),
-                                         tr("New name for profile <b>%1</b>:").
-                                            arg(profileName),
+    QString name = QInputDialog::getText(this,
+                                         tr("Rename..."),
+                                         tr("New name for profile <b>%1</b>:").arg(profileName),
                                          QLineEdit::Normal,
-                                         profileName, &ok);
+                                         profileName,
+                                         &ok);
     if (!ok)
         return;
 
@@ -449,7 +498,8 @@ void ROSCatkinToolsStepWidget::renameProfile(const QString profileName)
     if (name.isEmpty())
         return;
 
-    if (!ROSUtils::renameCatkinToolsProfile(m_makeStep->rosBuildConfiguration()->project()->projectDirectory(), profileName, name))
+    if (!ROSUtils::renameCatkinToolsProfile(
+            m_makeStep->rosBuildConfiguration()->project()->projectDirectory(), profileName, name))
         return;
 
     setProfile(name);
@@ -457,7 +507,10 @@ void ROSCatkinToolsStepWidget::renameProfile(const QString profileName)
 
 void ROSCatkinToolsStepWidget::editProfile(const QString profileName)
 {
-    Utils::FilePath profile = ROSUtils::getCatkinToolsProfile(m_makeStep->rosBuildConfiguration()->project()->projectDirectory(), profileName);
+    Utils::FilePath profile = ROSUtils::getCatkinToolsProfile(m_makeStep->rosBuildConfiguration()
+                                                                  ->project()
+                                                                  ->projectDirectory(),
+                                                              profileName);
 
     ROSCatkinToolsProfileEditorDialog *editor = new ROSCatkinToolsProfileEditorDialog(profile);
     editor->show();
@@ -465,19 +518,23 @@ void ROSCatkinToolsStepWidget::editProfile(const QString profileName)
 
 void ROSCatkinToolsStepWidget::removeProfile(const QString profileName)
 {
-    ROSUtils::removeCatkinToolsProfile(m_makeStep->rosBuildConfiguration()->project()->projectDirectory(), profileName);
-    setProfile(ROSUtils::getCatkinToolsProfileNames(m_makeStep->rosBuildConfiguration()->project()->projectDirectory())[0]);
+    ROSUtils::removeCatkinToolsProfile(m_makeStep->rosBuildConfiguration()
+                                           ->project()
+                                           ->projectDirectory(),
+                                       profileName);
+    setProfile(ROSUtils::getCatkinToolsProfileNames(
+        m_makeStep->rosBuildConfiguration()->project()->projectDirectory())[0]);
 }
 
 QString ROSCatkinToolsStepWidget::uniqueName(const QString &name, const bool &isRename)
 {
     QString result = name.trimmed();
-    QStringList profileNames = ROSUtils::getCatkinToolsProfileNames(m_makeStep->rosBuildConfiguration()->project()->projectDirectory());
+    QStringList profileNames = ROSUtils::getCatkinToolsProfileNames(
+        m_makeStep->rosBuildConfiguration()->project()->projectDirectory());
     if (!result.isEmpty()) {
-        if(isRename)
-        {
+        if (isRename) {
             QStringList pNames;
-            for (const QString& profile : profileNames) {
+            for (const QString &profile : profileNames) {
                 if (profile == m_makeStep->activeProfile())
                     continue;
                 pNames.append(profile);
@@ -495,23 +552,48 @@ QString ROSCatkinToolsStepWidget::uniqueName(const QString &name, const bool &is
 // ROSCatkinToolsListEditorWidget
 //
 
-ROSCatkinToolsListEditorWidget::ROSCatkinToolsListEditorWidget(QWidget *parent) : QDialog (parent)
+ROSCatkinToolsListEditorWidget::ROSCatkinToolsListEditorWidget(QWidget *parent)
+    : QDialog(parent)
 {
     m_ui = new Ui::ROSCatkinToolsListEditor;
     m_ui->setupUi(this);
     setWindowFlags(Qt::FramelessWindowHint | Qt::Dialog);
 
-    connect(m_ui->listWidget, &QListWidget::itemChanged, this, &ROSCatkinToolsListEditorWidget::listWidget_itemChanged);
-    connect(m_ui->listWidget, &QListWidget::itemSelectionChanged, this, &ROSCatkinToolsListEditorWidget::listWidget_itemSelectionChanged);
+    connect(m_ui->listWidget,
+            &QListWidget::itemChanged,
+            this,
+            &ROSCatkinToolsListEditorWidget::listWidget_itemChanged);
+    connect(m_ui->listWidget,
+            &QListWidget::itemSelectionChanged,
+            this,
+            &ROSCatkinToolsListEditorWidget::listWidget_itemSelectionChanged);
 
-    connect(m_ui->addPushButton, &QAbstractButton::clicked, this, &ROSCatkinToolsListEditorWidget::addPushButton_clicked);
-    connect(m_ui->removePushButton, &QAbstractButton::clicked, this, &ROSCatkinToolsListEditorWidget::removePushButton_clicked);
+    connect(m_ui->addPushButton,
+            &QAbstractButton::clicked,
+            this,
+            &ROSCatkinToolsListEditorWidget::addPushButton_clicked);
+    connect(m_ui->removePushButton,
+            &QAbstractButton::clicked,
+            this,
+            &ROSCatkinToolsListEditorWidget::removePushButton_clicked);
 
-    connect(m_ui->moveUpPushButton, &QAbstractButton::clicked, this, &ROSCatkinToolsListEditorWidget::moveUpPushButton_clicked);
-    connect(m_ui->moveDownPushButton, &QAbstractButton::clicked, this, &ROSCatkinToolsListEditorWidget::moveDownPushButton_clicked);
+    connect(m_ui->moveUpPushButton,
+            &QAbstractButton::clicked,
+            this,
+            &ROSCatkinToolsListEditorWidget::moveUpPushButton_clicked);
+    connect(m_ui->moveDownPushButton,
+            &QAbstractButton::clicked,
+            this,
+            &ROSCatkinToolsListEditorWidget::moveDownPushButton_clicked);
 
-    connect(m_ui->cancelPushButton, &QAbstractButton::clicked, this, &ROSCatkinToolsListEditorWidget::reject);
-    connect(m_ui->acceptPushButton, &QAbstractButton::clicked, this, &ROSCatkinToolsListEditorWidget::accept);
+    connect(m_ui->cancelPushButton,
+            &QAbstractButton::clicked,
+            this,
+            &ROSCatkinToolsListEditorWidget::reject);
+    connect(m_ui->acceptPushButton,
+            &QAbstractButton::clicked,
+            this,
+            &ROSCatkinToolsListEditorWidget::accept);
 }
 
 ROSCatkinToolsListEditorWidget::~ROSCatkinToolsListEditorWidget()
@@ -548,7 +630,7 @@ void ROSCatkinToolsListEditorWidget::listWidget_itemSelectionChanged()
     int cnt = m_ui->listWidget->count();
     int index = m_ui->listWidget->currentRow();
 
-    m_ui->moveDownPushButton->setEnabled(cnt > 1 && index != cnt-1);
+    m_ui->moveDownPushButton->setEnabled(cnt > 1 && index != cnt - 1);
     m_ui->moveUpPushButton->setEnabled(cnt > 1 && index != 0);
 }
 
@@ -561,19 +643,18 @@ void ROSCatkinToolsListEditorWidget::addPushButton_clicked()
 
 void ROSCatkinToolsListEditorWidget::removePushButton_clicked()
 {
-   qDeleteAll(m_ui->listWidget->selectedItems());
+    qDeleteAll(m_ui->listWidget->selectedItems());
 
-   listWidget_itemChanged();
+    listWidget_itemChanged();
 }
 
 void ROSCatkinToolsListEditorWidget::moveUpPushButton_clicked()
 {
     int currentIndex = m_ui->listWidget->currentRow();
-    if (currentIndex != -1)
-    {
+    if (currentIndex != -1) {
         QListWidgetItem *currentItem = m_ui->listWidget->takeItem(currentIndex);
-        m_ui->listWidget->insertItem(currentIndex-1, currentItem);
-        m_ui->listWidget->setCurrentRow(currentIndex-1);
+        m_ui->listWidget->insertItem(currentIndex - 1, currentItem);
+        m_ui->listWidget->setCurrentRow(currentIndex - 1);
 
         listWidget_itemChanged();
     }
@@ -582,11 +663,10 @@ void ROSCatkinToolsListEditorWidget::moveUpPushButton_clicked()
 void ROSCatkinToolsListEditorWidget::moveDownPushButton_clicked()
 {
     int currentIndex = m_ui->listWidget->currentRow();
-    if (currentIndex != -1)
-    {
+    if (currentIndex != -1) {
         QListWidgetItem *currentItem = m_ui->listWidget->takeItem(currentIndex);
-        m_ui->listWidget->insertItem(currentIndex+1, currentItem);
-        m_ui->listWidget->setCurrentRow(currentIndex+1);
+        m_ui->listWidget->insertItem(currentIndex + 1, currentItem);
+        m_ui->listWidget->setCurrentRow(currentIndex + 1);
 
         listWidget_itemChanged();
     }
@@ -595,25 +675,26 @@ void ROSCatkinToolsListEditorWidget::moveDownPushButton_clicked()
 void ROSCatkinToolsListEditorWidget::addItem(const QString &str)
 {
     QListWidgetItem *item = new QListWidgetItem();
-    item->setFlags(item->flags () | Qt::ItemIsEditable);
+    item->setFlags(item->flags() | Qt::ItemIsEditable);
     item->setText(str);
     m_ui->listWidget->addItem(item);
     m_ui->listWidget->setCurrentItem(item);
     m_ui->listWidget->editItem(item);
 }
 
-
 //
 // ROSCatkinToolsListWidget
 //
 
-ROSCatkinToolsListWidget::ROSCatkinToolsListWidget(QWidget *parent) : QLineEdit(parent)
+ROSCatkinToolsListWidget::ROSCatkinToolsListWidget(QWidget *parent)
+    : QLineEdit(parent)
 {
     this->setReadOnly(true);
     m_editor = new ROSCatkinToolsListEditorWidget(this);
 
     QAction *editor;
-    editor = this->addAction(QIcon(QLatin1String(":rosproject/pencil_icon.png")), QLineEdit::TrailingPosition);
+    editor = this->addAction(QIcon(QLatin1String(":rosproject/pencil_icon.png")),
+                             QLineEdit::TrailingPosition);
     connect(editor, SIGNAL(triggered(bool)), this, SLOT(onActionEditListTriggered()));
 }
 
@@ -628,7 +709,7 @@ void ROSCatkinToolsListWidget::onActionEditListTriggered()
     m_editor->setFixedSize(this->width(), m_editor->height());
     m_editor->move(globalPos);
 
-    if(m_editor->exec() == QDialog::Accepted)
+    if (m_editor->exec() == QDialog::Accepted)
         setList(m_editor->list());
 }
 
@@ -647,7 +728,8 @@ QStringList ROSCatkinToolsListWidget::list() const
 // ROSCatkinToolsConfigEditorWidget
 //
 
-ROSCatkinToolsConfigEditorWidget::ROSCatkinToolsConfigEditorWidget() : QWidget()
+ROSCatkinToolsConfigEditorWidget::ROSCatkinToolsConfigEditorWidget()
+    : QWidget()
 {
     m_ui = new Ui::ROSCatkinToolsConfigEditor;
     m_ui->setupUi(this);
@@ -655,32 +737,95 @@ ROSCatkinToolsConfigEditorWidget::ROSCatkinToolsConfigEditorWidget() : QWidget()
 
     m_editor = new ROSCatkinToolsListEditorWidget();
 
-    connect(m_ui->saveButton, &QAbstractButton::clicked, this, &ROSCatkinToolsConfigEditorWidget::saveProfileConfig);
+    connect(m_ui->saveButton,
+            &QAbstractButton::clicked,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::saveProfileConfig);
 
-    connect(m_ui->extend_path_chooser, &Utils::PathChooser::pathChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->extend_path_chooser,
+            &Utils::PathChooser::pathChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
 
-    connect(m_ui->blacklist_lineEdit, &QLineEdit::textChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->whitelist_lineEdit, &QLineEdit::textChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->space_source_lineEdit, &QLineEdit::textChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->space_build_lineEdit, &QLineEdit::textChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->space_devel_lineEdit, &QLineEdit::textChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->space_install_lineEdit, &QLineEdit::textChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->space_log_lineEdit, &QLineEdit::textChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->catkin_args_lineEdit, &QLineEdit::textChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->cmake_args_lineEdit, &QLineEdit::textChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->make_args_lineEdit, &QLineEdit::textChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->blacklist_lineEdit,
+            &QLineEdit::textChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->whitelist_lineEdit,
+            &QLineEdit::textChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->space_source_lineEdit,
+            &QLineEdit::textChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->space_build_lineEdit,
+            &QLineEdit::textChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->space_devel_lineEdit,
+            &QLineEdit::textChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->space_install_lineEdit,
+            &QLineEdit::textChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->space_log_lineEdit,
+            &QLineEdit::textChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->catkin_args_lineEdit,
+            &QLineEdit::textChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->cmake_args_lineEdit,
+            &QLineEdit::textChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->make_args_lineEdit,
+            &QLineEdit::textChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
 
-    connect(m_ui->space_devel_layout_comboBox, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->space_install_option_comboBox, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->space_install_layout_comboBox, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->space_devel_layout_comboBox,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->space_install_option_comboBox,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->space_install_layout_comboBox,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
 
-    connect(m_ui->jobs_checkBox, &QCheckBox::stateChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->package_jobs_checkBox, &QCheckBox::stateChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->env_cache_checkBox, &QCheckBox::stateChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->jobserver_checkBox, &QCheckBox::stateChanged, this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->jobs_checkBox,
+            &QCheckBox::stateChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->package_jobs_checkBox,
+            &QCheckBox::stateChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->env_cache_checkBox,
+            &QCheckBox::stateChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->jobserver_checkBox,
+            &QCheckBox::stateChanged,
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
 
-    connect(m_ui->jobs_spinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
-    connect(m_ui->package_jobs_spinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->jobs_spinBox,
+            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
+    connect(m_ui->package_jobs_spinBox,
+            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this,
+            &ROSCatkinToolsConfigEditorWidget::propertyChanged);
 }
 
 ROSCatkinToolsConfigEditorWidget::~ROSCatkinToolsConfigEditorWidget()
@@ -692,9 +837,10 @@ ROSCatkinToolsConfigEditorWidget::~ROSCatkinToolsConfigEditorWidget()
 bool ROSCatkinToolsConfigEditorWidget::parseProfileConfig(Utils::FilePath filePath)
 {
     m_profileConfigPath = filePath;
-    if (!m_profileConfigPath.exists())
-    {
-        Core::MessageManager::write(tr("[ROS Warning] Catkin Tools Profile Config File: %1, does not exist.").arg(m_profileConfigPath.toString()));
+    if (!m_profileConfigPath.exists()) {
+        Core::MessageManager::write(
+            tr("[ROS Warning] Catkin Tools Profile Config File: %1, does not exist.")
+                .arg(m_profileConfigPath.toString()));
         return false;
     }
     m_parsing = true;
@@ -741,7 +887,7 @@ QStringList ROSCatkinToolsConfigEditorWidget::parseList(const std::string &key) 
     if (!m_profile_current[key].IsSequence())
         return QStringList();
 
-    std::vector<std::string> vector_list = m_profile_current[key].as<std::vector<std::string> >();
+    std::vector<std::string> vector_list = m_profile_current[key].as<std::vector<std::string>>();
     return toQStringList(vector_list);
 }
 
@@ -764,7 +910,7 @@ bool ROSCatkinToolsConfigEditorWidget::parseBool(const std::string &key) const
 std::vector<std::string> ROSCatkinToolsConfigEditorWidget::toStdVector(const QStringList &list) const
 {
     std::vector<std::string> l;
-    for (auto const& str: list)
+    for (auto const &str : list)
         l.push_back(str.toStdString());
 
     return l;
@@ -773,7 +919,7 @@ std::vector<std::string> ROSCatkinToolsConfigEditorWidget::toStdVector(const QSt
 QStringList ROSCatkinToolsConfigEditorWidget::toQStringList(const std::vector<std::string> &list) const
 {
     QStringList l;
-    for (auto const& str: list)
+    for (auto const &str : list)
         l.append(QString::fromStdString(str));
 
     return l;
@@ -781,9 +927,10 @@ QStringList ROSCatkinToolsConfigEditorWidget::toQStringList(const std::vector<st
 
 bool ROSCatkinToolsConfigEditorWidget::saveProfileConfig()
 {
-    if (!m_profileConfigPath.exists())
-    {
-        Core::MessageManager::write(tr("[ROS Warning] Catkin Tools Profile Config File: %1, does not exist.").arg(m_profileConfigPath.toString()));
+    if (!m_profileConfigPath.exists()) {
+        Core::MessageManager::write(
+            tr("[ROS Warning] Catkin Tools Profile Config File: %1, does not exist.")
+                .arg(m_profileConfigPath.toString()));
         return false;
     }
 
@@ -800,31 +947,40 @@ bool ROSCatkinToolsConfigEditorWidget::saveProfileConfig()
 
 void ROSCatkinToolsConfigEditorWidget::propertyChanged()
 {
-    if (!m_parsing)
-    {
+    if (!m_parsing) {
         m_modified = true;
 
         if (!m_ui->extend_path_chooser->path().isEmpty())
-            m_profile_original["extend_path"] = m_ui->extend_path_chooser->path().trimmed().toStdString();
+            m_profile_original["extend_path"]
+                = m_ui->extend_path_chooser->path().trimmed().toStdString();
         else
             m_profile_original["extend_path"] = "null";
 
         m_profile_original["whitelist"] = toStdVector(m_ui->whitelist_lineEdit->list());
         m_profile_original["blacklist"] = toStdVector(m_ui->blacklist_lineEdit->list());
 
-        m_profile_original["source_space"] = m_ui->space_source_lineEdit->text().trimmed().toStdString();
-        m_profile_original["build_space"] = m_ui->space_build_lineEdit->text().trimmed().toStdString();
-        m_profile_original["devel_space"] = m_ui->space_devel_lineEdit->text().trimmed().toStdString();
-        m_profile_original["install_space"] = m_ui->space_install_lineEdit->text().trimmed().toStdString();
+        m_profile_original["source_space"]
+            = m_ui->space_source_lineEdit->text().trimmed().toStdString();
+        m_profile_original["build_space"]
+            = m_ui->space_build_lineEdit->text().trimmed().toStdString();
+        m_profile_original["devel_space"]
+            = m_ui->space_devel_lineEdit->text().trimmed().toStdString();
+        m_profile_original["install_space"]
+            = m_ui->space_install_lineEdit->text().trimmed().toStdString();
         m_profile_original["log_space"] = m_ui->space_log_lineEdit->text().trimmed().toStdString();
 
         m_profile_original["catkin_make_args"] = toStdVector(m_ui->catkin_args_lineEdit->list());
         m_profile_original["cmake_args"] = toStdVector(m_ui->cmake_args_lineEdit->list());
         m_profile_original["make_args"] = toStdVector(m_ui->make_args_lineEdit->list());
 
-        m_profile_original["devel_layout"] = m_ui->space_devel_layout_comboBox->currentText().toLower().trimmed().toStdString();
-        m_profile_original["install"] = m_ui->space_install_option_comboBox->currentIndex() ? "true" : "false";
-        m_profile_original["isolate_install"] = m_ui->space_install_layout_comboBox->currentIndex() ? "true" : "false";
+        m_profile_original["devel_layout"]
+            = m_ui->space_devel_layout_comboBox->currentText().toLower().trimmed().toStdString();
+        m_profile_original["install"] = m_ui->space_install_option_comboBox->currentIndex()
+                                            ? "true"
+                                            : "false";
+        m_profile_original["isolate_install"] = m_ui->space_install_layout_comboBox->currentIndex()
+                                                    ? "true"
+                                                    : "false";
 
         std::vector<std::string> jobs_args;
         if (m_ui->jobs_checkBox->checkState() == Qt::Checked)
@@ -834,8 +990,13 @@ void ROSCatkinToolsConfigEditorWidget::propertyChanged()
 
         //TODO: Need to figure out how to parse jobs and package jobs
 
-        m_profile_original["use_env_cache"] = m_ui->env_cache_checkBox->checkState() == Qt::Checked ? "true" : "false";
-        m_profile_original["use_internal_make_jobserver"] = m_ui->jobserver_checkBox->checkState() == Qt::Checked ? "true" : "false";
+        m_profile_original["use_env_cache"] = m_ui->env_cache_checkBox->checkState() == Qt::Checked
+                                                  ? "true"
+                                                  : "false";
+        m_profile_original["use_internal_make_jobserver"] = m_ui->jobserver_checkBox->checkState()
+                                                                    == Qt::Checked
+                                                                ? "true"
+                                                                : "false";
 
         m_ui->saveButton->setEnabled(isValid());
     }
@@ -865,7 +1026,8 @@ bool ROSCatkinToolsConfigEditorWidget::isValid() const
 // ROSCatkinToolsProfileEditorDialog
 //
 
-ROSCatkinToolsProfileEditorDialog::ROSCatkinToolsProfileEditorDialog(Utils::FilePath filePath) : QDialog()
+ROSCatkinToolsProfileEditorDialog::ROSCatkinToolsProfileEditorDialog(Utils::FilePath filePath)
+    : QDialog()
 {
     setWindowFlags(Qt::WindowStaysOnTopHint | Qt::Dialog);
     QVBoxLayout *vlayout = new QVBoxLayout();
@@ -873,7 +1035,7 @@ ROSCatkinToolsProfileEditorDialog::ROSCatkinToolsProfileEditorDialog(Utils::File
     vlayout->addWidget(editorWidget);
     setLayout(vlayout);
     setWindowTitle(QLatin1String("Catkin Tools Configuration Editor"));
-    if(!editorWidget->parseProfileConfig(filePath))
+    if (!editorWidget->parseProfileConfig(filePath))
         this->close();
 }
 
@@ -881,13 +1043,17 @@ ROSCatkinToolsProfileEditorDialog::ROSCatkinToolsProfileEditorDialog(Utils::File
 // ROSCatkinToolsStepFactory
 //
 
-ROSCatkinToolsStepFactory::ROSCatkinToolsStepFactory() : BuildStepFactory()
+ROSCatkinToolsStepFactory::ROSCatkinToolsStepFactory()
+    : BuildStepFactory()
 {
-  registerStep<ROSCatkinToolsStep>(ROS_CTS_ID);
-  setFlags(BuildStepInfo::Flags::UniqueStep);
-  setDisplayName(QCoreApplication::translate("ROSProjectManager::Internal::ROSCatkinToolsConfigStep", ROS_CTS_DISPLAY_NAME));
-  setSupportedProjectType(Constants::ROS_PROJECT_ID);
-  setSupportedStepLists({ProjectExplorer::Constants::BUILDSTEPS_BUILD, ProjectExplorer::Constants::BUILDSTEPS_CLEAN});
+    registerStep<ROSCatkinToolsStep>(ROS_CTS_ID);
+    setFlags(BuildStepInfo::Flags::UniqueStep);
+    setDisplayName(
+        QCoreApplication::translate("ROSProjectManager::Internal::ROSCatkinToolsConfigStep",
+                                    ROS_CTS_DISPLAY_NAME));
+    setSupportedProjectType(Constants::ROS_PROJECT_ID);
+    setSupportedStepLists({ProjectExplorer::Constants::BUILDSTEPS_BUILD,
+                           ProjectExplorer::Constants::BUILDSTEPS_CLEAN});
 }
 
 } // namespace Internal

--- a/src/project_manager/ros_catkin_tools_step.h
+++ b/src/project_manager/ros_catkin_tools_step.h
@@ -25,9 +25,9 @@
 
 #include "ros_build_configuration.h"
 
+#include <yaml-cpp/yaml.h>
 #include <QDialog>
 #include <QLineEdit>
-#include <yaml-cpp/yaml.h>
 
 QT_BEGIN_NAMESPACE
 class QListWidgetItem;
@@ -39,9 +39,11 @@ namespace Internal {
 
 class ROSCatkinToolsStepWidget;
 class ROSCatkinToolsStepFactory;
-namespace Ui {class ROSCatkinToolsStep;
-              class ROSCatkinToolsListEditor;
-              class ROSCatkinToolsConfigEditor;}
+namespace Ui {
+class ROSCatkinToolsStep;
+class ROSCatkinToolsListEditor;
+class ROSCatkinToolsConfigEditor;
+} // namespace Ui
 
 static const char ROS_CTS_ID[] = "ROSProjectManager.ROSCatkinToolsStep";
 
@@ -53,7 +55,7 @@ class ROSCatkinToolsStep : public ProjectExplorer::AbstractProcessStep
     friend class ROSCatkinToolsStepFactory;
 
 public:
-    enum BuildTargets {BUILD = 0, CLEAN = 1};
+    enum BuildTargets { BUILD = 0, CLEAN = 1 };
 
     ROSCatkinToolsStep(ProjectExplorer::BuildStepList *parent, Utils::Id id);
     ~ROSCatkinToolsStep() override;
@@ -130,7 +132,6 @@ class ROSCatkinToolsProfileEditorDialog : public QDialog
     Q_OBJECT
 public:
     ROSCatkinToolsProfileEditorDialog(Utils::FilePath filePath);
-
 };
 
 class ROSCatkinToolsListEditorWidget : public QDialog
@@ -160,7 +161,7 @@ private:
     QStringList m_list;
 };
 
-class ROSCatkinToolsListWidget: public QLineEdit
+class ROSCatkinToolsListWidget : public QLineEdit
 {
     Q_OBJECT
 public:
@@ -208,7 +209,6 @@ private:
     YAML::Node m_profile_original;
     YAML::Node m_profile_current;
 };
-
 
 class ROSCatkinToolsStepFactory : public ProjectExplorer::BuildStepFactory
 {

--- a/src/project_manager/ros_colcon_step.h
+++ b/src/project_manager/ros_colcon_step.h
@@ -21,8 +21,8 @@
 #ifndef ROSCOLCONSTEP_H
 #define ROSCOLCONSTEP_H
 
-#include <projectexplorer/abstractprocessstep.h>
 #include "ros_build_configuration.h"
+#include <projectexplorer/abstractprocessstep.h>
 
 QT_BEGIN_NAMESPACE
 class QListWidgetItem;
@@ -33,7 +33,9 @@ namespace Internal {
 
 class ROSColconStepWidget;
 class ROSColconStepFactory;
-namespace Ui { class ROSColconStep; }
+namespace Ui {
+class ROSColconStep;
+}
 
 static const char ROS_COLCON_STEP_ID[] = "ROSProjectManager.ROSColconStep";
 
@@ -45,7 +47,7 @@ class ROSColconStep : public ProjectExplorer::AbstractProcessStep
     friend class ROSColconStepFactory;
 
 public:
-    enum BuildTargets {BUILD = 0, CLEAN = 1};
+    enum BuildTargets { BUILD = 0, CLEAN = 1 };
 
     ROSColconStep(ProjectExplorer::BuildStepList *parent, Utils::Id id);
     ~ROSColconStep() override;

--- a/src/project_manager/ros_generic_run_step.cpp
+++ b/src/project_manager/ros_generic_run_step.cpp
@@ -19,12 +19,12 @@
  * limitations under the License.
  */
 #include "ros_generic_run_step.h"
-#include "ros_project.h"
 #include "ros_build_configuration.h"
+#include "ros_project.h"
 #include "ui_ros_generic_configuration.h"
 
-#include <projectexplorer/buildmanager.h>
 #include <coreplugin/messagemanager.h>
+#include <projectexplorer/buildmanager.h>
 
 #include <QStringListModel>
 
@@ -37,29 +37,26 @@ const char ROS_GENERIC_PACKAGE_PATH_KEY[] = "ROSProjectManager.ROSGenericStep.Pa
 const char ROS_GENERIC_TARGET_KEY[] = "ROSProjectManager.ROSGenericStep.Target";
 const char ROS_GENERIC_TARGET_PATH_KEY[] = "ROSProjectManager.ROSGenericStep.TargetPath";
 const char ROS_GENERIC_ARGUMENTS_KEY[] = "ROSProjectManager.ROSGenericStep.Arguments";
-const char ROS_GENERIC_DEBUG_CONTINUE_ON_ATTACH_KEY[] = "ROSProjectManager.ROSGenericStep.DebugContinueOnAttach";
+const char ROS_GENERIC_DEBUG_CONTINUE_ON_ATTACH_KEY[]
+    = "ROSProjectManager.ROSGenericStep.DebugContinueOnAttach";
 
-ROSGenericRunStep::ROSGenericRunStep(RunStepList *rsl, Utils::Id id) : RunStep(rsl, id)
-{
-}
+ROSGenericRunStep::ROSGenericRunStep(RunStepList *rsl, Utils::Id id)
+    : RunStep(rsl, id)
+{}
 
-ROSGenericRunStep::~ROSGenericRunStep()
-{
-}
+ROSGenericRunStep::~ROSGenericRunStep() {}
 
 bool ROSGenericRunStep::init(QList<const RunStep *> &earlierSteps)
 {
     Q_UNUSED(earlierSteps);
 
     ROSRunConfiguration *rc = rosRunConfiguration();
-    if (!rc)
-    {
-      rc = targetsActiveRunConfiguration();
+    if (!rc) {
+        rc = targetsActiveRunConfiguration();
 
-      if (!rc)
-      {
-          return false;
-      }
+        if (!rc) {
+            return false;
+        }
     }
 
     return true;
@@ -67,47 +64,49 @@ bool ROSGenericRunStep::init(QList<const RunStep *> &earlierSteps)
 
 void ROSGenericRunStep::run()
 {
-  ROSProject *rp = qobject_cast<ROSProject *>(target()->project());
+    ROSProject *rp = qobject_cast<ROSProject *>(target()->project());
 
-  QString command;
-  command = QString("%1 %2 %3 %4\n")
-      .arg(m_command,
-           m_package,
-           m_target,
-           m_arguments);
+    QString command;
+    command = QString("%1 %2 %3 %4\n").arg(m_command, m_package, m_target, m_arguments);
 
-  ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(rp->projectDirectory(), rp->rosBuildConfiguration()->rosBuildSystem(), rp->distribution());
-  ROSBuildConfiguration *bc = qobject_cast<ROSBuildConfiguration *>(target()->activeBuildConfiguration());
-  Utils::Environment env = bc->environment();
-  Utils::FilePath shell = Utils::FilePath::fromString(env.value("SHELL"));
-  QString source_cmd;
+    ROSUtils::WorkspaceInfo workspaceInfo
+        = ROSUtils::getWorkspaceInfo(rp->projectDirectory(),
+                                     rp->rosBuildConfiguration()->rosBuildSystem(),
+                                     rp->distribution());
+    ROSBuildConfiguration *bc = qobject_cast<ROSBuildConfiguration *>(
+        target()->activeBuildConfiguration());
+    Utils::Environment env = bc->environment();
+    Utils::FilePath shell = Utils::FilePath::fromString(env.value("SHELL"));
+    QString source_cmd;
 
-  Utils::FilePath sourcePath(workspaceInfo.develPath);
-  if (workspaceInfo.install)
-    sourcePath = Utils::FilePath(workspaceInfo.installPath);
+    Utils::FilePath sourcePath(workspaceInfo.develPath);
+    if (workspaceInfo.install)
+        sourcePath = Utils::FilePath(workspaceInfo.installPath);
 
-  if (shell.fileName() == "bash")
-      source_cmd = QString("source %1\n").arg(sourcePath.pathAppended("setup.bash").toString());
-  else if (shell.fileName() == "sh")
-      source_cmd = QString("source %1\n").arg(sourcePath.pathAppended("setup.sh").toString());
-  else if (shell.fileName() == "zsh")
-       source_cmd = QString("source %1\n").arg(sourcePath.pathAppended("setup.zsh").toString());
-  else
-       Core::MessageManager::write(tr("[ROS Error] The shell: %1 is currently not supported (Use bash, sh, or zsh)!").arg(shell.toString()));
+    if (shell.fileName() == "bash")
+        source_cmd = QString("source %1\n").arg(sourcePath.pathAppended("setup.bash").toString());
+    else if (shell.fileName() == "sh")
+        source_cmd = QString("source %1\n").arg(sourcePath.pathAppended("setup.sh").toString());
+    else if (shell.fileName() == "zsh")
+        source_cmd = QString("source %1\n").arg(sourcePath.pathAppended("setup.zsh").toString());
+    else
+        Core::MessageManager::write(
+            tr("[ROS Error] The shell: %1 is currently not supported (Use bash, sh, or zsh)!")
+                .arg(shell.toString()));
 
-  //create terminal without starting shell
-  QTermWidget &terminal = ROSProjectPlugin::instance()->startTerminal(0, command);
+    //create terminal without starting shell
+    QTermWidget &terminal = ROSProjectPlugin::instance()->startTerminal(0, command);
 
-  terminal.setWorkingDirectory(rp->projectDirectory().toString());
+    terminal.setWorkingDirectory(rp->projectDirectory().toString());
 
-  //start bash now that everything is setup
-  terminal.startShellProgram();
+    //start bash now that everything is setup
+    terminal.startShellProgram();
 
-  // source workspace (This is a hack because the setEnvironment is not working as I expected)
-  terminal.sendText(source_cmd);
+    // source workspace (This is a hack because the setEnvironment is not working as I expected)
+    terminal.sendText(source_cmd);
 
-  //send roslaunch command
-  terminal.sendText(command);
+    //send roslaunch command
+    terminal.sendText(command);
 }
 
 QVariantMap ROSGenericRunStep::toMap() const
@@ -155,32 +154,32 @@ RunStepConfigWidget *ROSGenericRunStep::createConfigWidget()
 
 QString ROSGenericRunStep::getCommand() const
 {
-  return m_command;
+    return m_command;
 }
 
 QString ROSGenericRunStep::getPackage() const
 {
-  return m_package;
+    return m_package;
 }
 
 QString ROSGenericRunStep::getPackagePath() const
 {
-  return m_package_path;
+    return m_package_path;
 }
 
 QString ROSGenericRunStep::getTarget() const
 {
-  return m_target;
+    return m_target;
 }
 
 QString ROSGenericRunStep::getTargetPath() const
 {
-  return m_targetPath;
+    return m_targetPath;
 }
 
 QString ROSGenericRunStep::getArguments() const
 {
-  return m_arguments;
+    return m_arguments;
 }
 
 bool ROSGenericRunStep::getDebugContinueOnAttach() const
@@ -190,110 +189,111 @@ bool ROSGenericRunStep::getDebugContinueOnAttach() const
 
 void ROSGenericRunStep::setCommand(const QString &command)
 {
-  m_command = command;
+    m_command = command;
 }
 
 void ROSGenericRunStep::setPackage(const QString &package)
 {
-  m_package = package;
+    m_package = package;
 }
 
 void ROSGenericRunStep::setPackagePath(const QString &package)
 {
-  m_package_path = package;
+    m_package_path = package;
 }
 
 void ROSGenericRunStep::setTarget(const QString &target)
 {
-  m_target = target;
+    m_target = target;
 }
 
 void ROSGenericRunStep::setTargetPath(const QString &targetPath)
 {
-  m_targetPath = targetPath;
+    m_targetPath = targetPath;
 }
 
 void ROSGenericRunStep::setArguments(const QString &arguments)
 {
-  m_arguments = arguments;
+    m_arguments = arguments;
 }
 
 void ROSGenericRunStep::setDebugContinueOnAttach(const bool &contOnAttach)
 {
-  m_debugContinueOnAttach = contOnAttach;
+    m_debugContinueOnAttach = contOnAttach;
 }
 
 //
 // ROSGenericRunStepConfigWidget
 //
 
-ROSGenericRunStepConfigWidget::ROSGenericRunStepConfigWidget(ROSGenericRunStep *genericStep, bool packages_show, bool args_show, bool debug_show)
-    : m_rosGenericStep(genericStep),
-      m_packageNames(new QStringListModel()),
-      m_targetNames(new QStringListModel())
+ROSGenericRunStepConfigWidget::ROSGenericRunStepConfigWidget(ROSGenericRunStep *genericStep,
+                                                             bool packages_show,
+                                                             bool args_show,
+                                                             bool debug_show)
+    : m_rosGenericStep(genericStep)
+    , m_packageNames(new QStringListModel())
+    , m_targetNames(new QStringListModel())
 {
     m_ui = new Ui::ROSGenericStep();
     m_ui->setupUi(this);
 
-
-    if (!packages_show)
-    {
+    if (!packages_show) {
         m_ui->packageLabel->hide();
         m_ui->packageComboBox->hide();
 
         m_ui->targetLabel->hide();
         m_ui->targetComboBox->hide();
+    } else {
+        m_ui->packageComboBox->setStyleSheet(tr("combobox-popup: 0;"));
+        m_ui->packageComboBox->setModel(m_packageNames);
+        m_ui->targetComboBox->setStyleSheet(tr("combobox-popup: 0;"));
+        m_ui->targetComboBox->setModel(m_targetNames);
+
+        int idx;
+        updateAvailablePackages();
+        idx = m_ui->packageComboBox->findText(genericStep->getPackage(), Qt::MatchExactly);
+        m_ui->packageComboBox->setCurrentIndex(idx);
+
+        updateAvailableTargets();
+        idx = m_ui->targetComboBox->findText(genericStep->getTarget(), Qt::MatchExactly);
+        m_ui->targetComboBox->setCurrentIndex(idx);
+
+        connect(m_ui->packageComboBox,
+                SIGNAL(currentIndexChanged(QString)),
+                this,
+                SLOT(packageComboBox_currentIndexChanged(QString)));
+
+        connect(m_ui->targetComboBox,
+                SIGNAL(currentIndexChanged(QString)),
+                this,
+                SLOT(targetComboBox_currentIndexChanged(QString)));
     }
-    else
-    {
-      m_ui->packageComboBox->setStyleSheet(tr("combobox-popup: 0;"));
-      m_ui->packageComboBox->setModel(m_packageNames);
-      m_ui->targetComboBox->setStyleSheet(tr("combobox-popup: 0;"));
-      m_ui->targetComboBox->setModel(m_targetNames);
 
-      int idx;
-      updateAvailablePackages();
-      idx = m_ui->packageComboBox->findText(genericStep->getPackage(), Qt::MatchExactly);
-      m_ui->packageComboBox->setCurrentIndex(idx);
-
-      updateAvailableTargets();
-      idx = m_ui->targetComboBox->findText(genericStep->getTarget(), Qt::MatchExactly);
-      m_ui->targetComboBox->setCurrentIndex(idx);
-
-      connect(m_ui->packageComboBox, SIGNAL(currentIndexChanged(QString)),
-              this, SLOT(packageComboBox_currentIndexChanged(QString)));
-
-      connect(m_ui->targetComboBox, SIGNAL(currentIndexChanged(QString)),
-              this, SLOT(targetComboBox_currentIndexChanged(QString)));
-    }
-
-    if (!args_show)
-    {
+    if (!args_show) {
         m_ui->argumentsLabel->hide();
         m_ui->argumentsLineEdit->hide();
-    }
-    else
-    {
+    } else {
         m_ui->argumentsLineEdit->setText(genericStep->getArguments());
 
-        connect(m_ui->argumentsLineEdit, SIGNAL(textChanged(QString)),
-                this, SLOT(argumentsLineEdit_textChanged(QString)));
+        connect(m_ui->argumentsLineEdit,
+                SIGNAL(textChanged(QString)),
+                this,
+                SLOT(argumentsLineEdit_textChanged(QString)));
     }
 
     if (!debug_show) //Note this only used for Attach to Node Run Step
     {
         m_ui->debugLabel->hide();
         m_ui->debugCheckBox->hide();
-    }
-    else
-    {
+    } else {
         m_ui->debugCheckBox->setChecked(genericStep->getDebugContinueOnAttach());
-        connect(m_ui->debugCheckBox, SIGNAL(toggled(bool)),
-                this, SLOT(debugCheckBox_toggled(bool)));
+        connect(m_ui->debugCheckBox, SIGNAL(toggled(bool)), this, SLOT(debugCheckBox_toggled(bool)));
     }
 
-    connect(ProjectExplorer::BuildManager::instance(), &ProjectExplorer::BuildManager::buildQueueFinished,
-            this, &ROSGenericRunStepConfigWidget::updateAvailablePackages);
+    connect(ProjectExplorer::BuildManager::instance(),
+            &ProjectExplorer::BuildManager::buildQueueFinished,
+            this,
+            &ROSGenericRunStepConfigWidget::updateAvailablePackages);
 }
 
 ROSGenericRunStepConfigWidget::~ROSGenericRunStepConfigWidget()
@@ -306,7 +306,8 @@ void ROSGenericRunStepConfigWidget::updateAvailablePackages()
     QString cachePkgName = m_ui->packageComboBox->currentText();
     QString cachePkgTarget = m_ui->targetComboBox->currentText();
 
-    ROSBuildConfiguration *bc = qobject_cast<ROSBuildConfiguration *>(m_rosGenericStep->target()->activeBuildConfiguration());
+    ROSBuildConfiguration *bc = qobject_cast<ROSBuildConfiguration *>(
+        m_rosGenericStep->target()->activeBuildConfiguration());
     m_availablePackages = ROSUtils::getROSPackages(bc->environment().toStringList());
     m_packageNames->setStringList(m_availablePackages.keys());
 
@@ -321,13 +322,13 @@ QString ROSGenericRunStepConfigWidget::displayName() const
 
 QString ROSGenericRunStepConfigWidget::summaryText() const
 {
-  //this is causing a the plugin to crash
-  return QString("<b>%1:</b> %2 %3 %4 %5")
-          .arg(displayName(),
-               m_rosGenericStep->getCommand(),
-               m_rosGenericStep->getPackage(),
-               m_rosGenericStep->getTarget(),
-               m_rosGenericStep->getArguments());
+    //this is causing a the plugin to crash
+    return QString("<b>%1:</b> %2 %3 %4 %5")
+        .arg(displayName(),
+             m_rosGenericStep->getCommand(),
+             m_rosGenericStep->getPackage(),
+             m_rosGenericStep->getTarget(),
+             m_rosGenericStep->getArguments());
 }
 
 void ROSGenericRunStepConfigWidget::debugCheckBox_toggled(const bool &arg1)
@@ -337,25 +338,25 @@ void ROSGenericRunStepConfigWidget::debugCheckBox_toggled(const bool &arg1)
 
 void ROSGenericRunStepConfigWidget::packageComboBox_currentIndexChanged(const QString &arg1)
 {
-  m_rosGenericStep->setPackage(arg1);
-  m_rosGenericStep->setPackagePath(m_availablePackages[arg1]);
-  m_ui->targetComboBox->clear();
-  updateAvailableTargets();
+    m_rosGenericStep->setPackage(arg1);
+    m_rosGenericStep->setPackagePath(m_availablePackages[arg1]);
+    m_ui->targetComboBox->clear();
+    updateAvailableTargets();
 
-  emit updateSummary();
+    emit updateSummary();
 }
 
 void ROSGenericRunStepConfigWidget::targetComboBox_currentIndexChanged(const QString &arg1)
 {
-  m_rosGenericStep->setTarget(arg1);
-  m_rosGenericStep->setTargetPath(m_availableTargets[arg1]);
-  emit updateSummary();
+    m_rosGenericStep->setTarget(arg1);
+    m_rosGenericStep->setTargetPath(m_availableTargets[arg1]);
+    emit updateSummary();
 }
 
 void ROSGenericRunStepConfigWidget::argumentsLineEdit_textChanged(const QString &arg1)
 {
-  m_rosGenericStep->setArguments(arg1);
-  emit updateSummary();
+    m_rosGenericStep->setArguments(arg1);
+    emit updateSummary();
 }
 
 void ROSGenericRunStepConfigWidget::updateAvailableTargets()

--- a/src/project_manager/ros_generic_run_step.h
+++ b/src/project_manager/ros_generic_run_step.h
@@ -21,14 +21,15 @@
 #ifndef ROS_GENERIC_RUN_STEP_H
 #define ROS_GENERIC_RUN_STEP_H
 
-#include "ros_run_step.h"
 #include "ros_run_configuration.h"
+#include "ros_run_step.h"
 
 namespace ROSProjectManager {
 namespace Internal {
 
-
-namespace Ui { class ROSGenericStep; }
+namespace Ui {
+class ROSGenericStep;
+}
 
 class ROSGenericRunStep : public RunStep
 {
@@ -87,7 +88,10 @@ class ROSGenericRunStepConfigWidget : public RunStepConfigWidget
     Q_OBJECT
 
 public:
-    ROSGenericRunStepConfigWidget(ROSGenericRunStep *genericStep, bool packages_show, bool targets_show, bool debug_show);
+    ROSGenericRunStepConfigWidget(ROSGenericRunStep *genericStep,
+                                  bool packages_show,
+                                  bool targets_show,
+                                  bool debug_show);
     ~ROSGenericRunStepConfigWidget();
     QString summaryText() const override;
     QString displayName() const override;
@@ -102,17 +106,17 @@ private slots:
     void argumentsLineEdit_textChanged(const QString &arg1);
 
 private:
-      void updateAvailableTargets();
-      void updateAvailablePackages();
+    void updateAvailableTargets();
+    void updateAvailablePackages();
 
-      Ui::ROSGenericStep *m_ui;
-      ROSGenericRunStep *m_rosGenericStep;
-      QMap<QString, QString> m_availablePackages;
-      QMap<QString, QString> m_availableTargets;
-      QStringListModel *m_packageNames;
-      QStringListModel *m_targetNames;
+    Ui::ROSGenericStep *m_ui;
+    ROSGenericRunStep *m_rosGenericStep;
+    QMap<QString, QString> m_availablePackages;
+    QMap<QString, QString> m_availableTargets;
+    QStringListModel *m_packageNames;
+    QStringListModel *m_targetNames;
 };
 
-} // Internal
-} // ROSProjectManager
+} // namespace Internal
+} // namespace ROSProjectManager
 #endif // ROS_GENERIC_RUN_STEP_H

--- a/src/project_manager/ros_package_wizard.cpp
+++ b/src/project_manager/ros_package_wizard.cpp
@@ -19,36 +19,36 @@
  * limitations under the License.
  */
 #include "ros_package_wizard.h"
+#include "ros_build_configuration.h"
+#include "ros_project.h"
+#include "ros_project_constants.h"
 #include "ros_utils.h"
 #include "ui_ros_package_wizard_details_page.h"
-#include "ros_project_constants.h"
-#include "ros_project.h"
-#include "ros_build_configuration.h"
 
-#include <coreplugin/icore.h>
 #include <coreplugin/coreicons.h>
+#include <coreplugin/icore.h>
 #include <coreplugin/messagemanager.h>
-#include <projectexplorer/projectexplorerconstants.h>
 #include <projectexplorer/customwizard/customwizard.h>
+#include <projectexplorer/projectexplorerconstants.h>
 #include <projectexplorer/projecttree.h>
 
 #include <utils/filewizardpage.h>
 #include <utils/mimetypes/mimedatabase.h>
 #include <utils/wizard.h>
 
+#include <projectexplorer/projecttree.h>
 #include <QApplication>
 #include <QDebug>
 #include <QDir>
 #include <QDirIterator>
 #include <QFileInfo>
+#include <QMessageBox>
 #include <QPainter>
 #include <QPixmap>
-#include <QStyle>
-#include <QProcess>
-#include <QXmlStreamReader>
 #include <QPlainTextEdit>
-#include <QMessageBox>
-#include <projectexplorer/projecttree.h>
+#include <QProcess>
+#include <QStyle>
+#include <QXmlStreamReader>
 
 #include <functional>
 
@@ -62,10 +62,9 @@ namespace Internal {
 //////////////////////////////////////////////////////////////////////////////
 
 ROSPackageWizardDialog::ROSPackageWizardDialog(const Core::BaseFileWizardFactory *factory,
-                                                       QWidget *parent) :
-    Core::BaseFileWizard(factory, QVariantMap(), parent)
+                                               QWidget *parent)
+    : Core::BaseFileWizard(factory, QVariantMap(), parent)
 {
-
     setWindowTitle(tr("Create ROS Package"));
 
     // first page
@@ -75,29 +74,65 @@ ROSPackageWizardDialog::ROSPackageWizardDialog(const Core::BaseFileWizardFactory
     addPage(m_detailsPage);
 }
 
-void ROSPackageWizardDialog::setPath(const QString &path) {m_detailsPage->setPath(path);}
+void ROSPackageWizardDialog::setPath(const QString &path)
+{
+    m_detailsPage->setPath(path);
+}
 
-void ROSPackageWizardDialog::setProjectDirectory(const QString &path) {m_detailsPage->setProjectDirectory(path);}
+void ROSPackageWizardDialog::setProjectDirectory(const QString &path)
+{
+    m_detailsPage->setProjectDirectory(path);
+}
 
-QString ROSPackageWizardDialog::packageName() const {return m_detailsPage->packageName();}
+QString ROSPackageWizardDialog::packageName() const
+{
+    return m_detailsPage->packageName();
+}
 
-QString ROSPackageWizardDialog::packagePath() const {return m_detailsPage->packagePath();}
+QString ROSPackageWizardDialog::packagePath() const
+{
+    return m_detailsPage->packagePath();
+}
 
-QString ROSPackageWizardDialog::version() const {return m_detailsPage->version();}
+QString ROSPackageWizardDialog::version() const
+{
+    return m_detailsPage->version();
+}
 
-QString ROSPackageWizardDialog::licenses() const {return m_detailsPage->licenses();}
+QString ROSPackageWizardDialog::licenses() const
+{
+    return m_detailsPage->licenses();
+}
 
-QString ROSPackageWizardDialog::description() const {return m_detailsPage->description();}
+QString ROSPackageWizardDialog::description() const
+{
+    return m_detailsPage->description();
+}
 
-QStringList ROSPackageWizardDialog::authors() const {return m_detailsPage->authors();}
+QStringList ROSPackageWizardDialog::authors() const
+{
+    return m_detailsPage->authors();
+}
 
-QStringList ROSPackageWizardDialog::maintainers() const {return m_detailsPage->maintainers();}
+QStringList ROSPackageWizardDialog::maintainers() const
+{
+    return m_detailsPage->maintainers();
+}
 
-QStringList ROSPackageWizardDialog::catkin_dependencies() const {return m_detailsPage->catkin_dependencies();}
+QStringList ROSPackageWizardDialog::catkin_dependencies() const
+{
+    return m_detailsPage->catkin_dependencies();
+}
 
-QStringList ROSPackageWizardDialog::system_dependencies() const {return m_detailsPage->system_dependencies();}
+QStringList ROSPackageWizardDialog::system_dependencies() const
+{
+    return m_detailsPage->system_dependencies();
+}
 
-QStringList ROSPackageWizardDialog::boost_components() const {return m_detailsPage->boost_components();}
+QStringList ROSPackageWizardDialog::boost_components() const
+{
+    return m_detailsPage->boost_components();
+}
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -110,43 +145,58 @@ public:
     ROSPackageWizardDetailsPagePrivate();
     Ui::ROSPackageWizardDetailsPage m_ui;
     bool m_complete;
-
 };
 
-ROSPackageWizardDetailsPagePrivate::ROSPackageWizardDetailsPagePrivate() :
-    m_complete(false)
-{
-}
+ROSPackageWizardDetailsPagePrivate::ROSPackageWizardDetailsPagePrivate()
+    : m_complete(false)
+{}
 
 //////////////////////////////////////////////////////////////////////////////
 //
 // ROSPackageWizardDetailsPage
 //
 //////////////////////////////////////////////////////////////////////////////
-ROSPackageWizardDetailsPage::ROSPackageWizardDetailsPage(QWidget *parent) :
-    WizardPage(parent),
-    d(new ROSPackageWizardDetailsPagePrivate)
+ROSPackageWizardDetailsPage::ROSPackageWizardDetailsPage(QWidget *parent)
+    : WizardPage(parent)
+    , d(new ROSPackageWizardDetailsPagePrivate)
 {
     d->m_ui.setupUi(this);
 
-    std::function<bool(Utils::FancyLineEdit *, QString *)> fn = std::bind( &ROSPackageWizardDetailsPage::validateWithValidator, this, std::placeholders::_1, std::placeholders::_2);
+    std::function<bool(Utils::FancyLineEdit *, QString *)> fn
+        = std::bind(&ROSPackageWizardDetailsPage::validateWithValidator,
+                    this,
+                    std::placeholders::_1,
+                    std::placeholders::_2);
     d->m_ui.pathChooser->setValidationFunction(fn);
 
-    connect(d->m_ui.pathChooser, &Utils::PathChooser::validChanged,
-            this, &ROSPackageWizardDetailsPage::slotPackagePathValidChanged);
-    connect(d->m_ui.packageNameLineEdit, &Utils::FancyLineEdit::validChanged,
-            this, &ROSPackageWizardDetailsPage::slotPackageNameValidChanged);
+    connect(d->m_ui.pathChooser,
+            &Utils::PathChooser::validChanged,
+            this,
+            &ROSPackageWizardDetailsPage::slotPackagePathValidChanged);
+    connect(d->m_ui.packageNameLineEdit,
+            &Utils::FancyLineEdit::validChanged,
+            this,
+            &ROSPackageWizardDetailsPage::slotPackageNameValidChanged);
 
-    connect(d->m_ui.pathChooser, &Utils::PathChooser::returnPressed,
-            this, &ROSPackageWizardDetailsPage::slotActivated);
-    connect(d->m_ui.packageNameLineEdit, &Utils::FancyLineEdit::validReturnPressed,
-            this, &ROSPackageWizardDetailsPage::slotActivated);
-
+    connect(d->m_ui.pathChooser,
+            &Utils::PathChooser::returnPressed,
+            this,
+            &ROSPackageWizardDetailsPage::slotActivated);
+    connect(d->m_ui.packageNameLineEdit,
+            &Utils::FancyLineEdit::validReturnPressed,
+            this,
+            &ROSPackageWizardDetailsPage::slotActivated);
 }
 
-ROSPackageWizardDetailsPage::~ROSPackageWizardDetailsPage() {delete d;}
+ROSPackageWizardDetailsPage::~ROSPackageWizardDetailsPage()
+{
+    delete d;
+}
 
-void ROSPackageWizardDetailsPage::setPath(const QString &path) {d->m_ui.pathChooser->setPath(path);}
+void ROSPackageWizardDetailsPage::setPath(const QString &path)
+{
+    d->m_ui.pathChooser->setPath(path);
+}
 
 void ROSPackageWizardDetailsPage::setProjectDirectory(const QString &path)
 {
@@ -154,35 +204,75 @@ void ROSPackageWizardDetailsPage::setProjectDirectory(const QString &path)
     d->m_ui.pathChooser->lineEdit()->setPlaceholderText(path);
 }
 
-QString ROSPackageWizardDetailsPage::packageName() const {return d->m_ui.packageNameLineEdit->text();}
+QString ROSPackageWizardDetailsPage::packageName() const
+{
+    return d->m_ui.packageNameLineEdit->text();
+}
 
-QString ROSPackageWizardDetailsPage::packagePath() const {return d->m_ui.pathChooser->path();}
+QString ROSPackageWizardDetailsPage::packagePath() const
+{
+    return d->m_ui.pathChooser->path();
+}
 
-QString ROSPackageWizardDetailsPage::version() const {return d->m_ui.versionLineEdit->text();}
+QString ROSPackageWizardDetailsPage::version() const
+{
+    return d->m_ui.versionLineEdit->text();
+}
 
-QString ROSPackageWizardDetailsPage::licenses() const {return d->m_ui.licenseComboBox->currentText();}
+QString ROSPackageWizardDetailsPage::licenses() const
+{
+    return d->m_ui.licenseComboBox->currentText();
+}
 
-QString ROSPackageWizardDetailsPage::description() const {return d->m_ui.descriptionPlainTextEdit->toPlainText();}
+QString ROSPackageWizardDetailsPage::description() const
+{
+    return d->m_ui.descriptionPlainTextEdit->toPlainText();
+}
 
-QStringList ROSPackageWizardDetailsPage::authors() const {return processList(d->m_ui.authorsLineEdit->text());}
+QStringList ROSPackageWizardDetailsPage::authors() const
+{
+    return processList(d->m_ui.authorsLineEdit->text());
+}
 
-QStringList ROSPackageWizardDetailsPage::maintainers() const {return processList(d->m_ui.maintainersLineEdit->text());}
+QStringList ROSPackageWizardDetailsPage::maintainers() const
+{
+    return processList(d->m_ui.maintainersLineEdit->text());
+}
 
-QStringList ROSPackageWizardDetailsPage::catkin_dependencies() const {return processList(d->m_ui.catkinLineEdit->text());}
+QStringList ROSPackageWizardDetailsPage::catkin_dependencies() const
+{
+    return processList(d->m_ui.catkinLineEdit->text());
+}
 
-QStringList ROSPackageWizardDetailsPage::system_dependencies() const {return processList(d->m_ui.systemLineEdit->text());}
+QStringList ROSPackageWizardDetailsPage::system_dependencies() const
+{
+    return processList(d->m_ui.systemLineEdit->text());
+}
 
-QStringList ROSPackageWizardDetailsPage::boost_components() const {return processList(d->m_ui.boostLineEdit->text());}
+QStringList ROSPackageWizardDetailsPage::boost_components() const
+{
+    return processList(d->m_ui.boostLineEdit->text());
+}
 
-bool ROSPackageWizardDetailsPage::isComplete() const {return d->m_complete;}
+bool ROSPackageWizardDetailsPage::isComplete() const
+{
+    return d->m_complete;
+}
 
-void ROSPackageWizardDetailsPage::slotPackageNameValidChanged() {validChangedHelper();}
+void ROSPackageWizardDetailsPage::slotPackageNameValidChanged()
+{
+    validChangedHelper();
+}
 
-void ROSPackageWizardDetailsPage::slotPackagePathValidChanged() {validChangedHelper();}
+void ROSPackageWizardDetailsPage::slotPackagePathValidChanged()
+{
+    validChangedHelper();
+}
 
 void ROSPackageWizardDetailsPage::validChangedHelper()
 {
-    const bool newComplete = d->m_ui.pathChooser->isValid() && d->m_ui.packageNameLineEdit->isValid();
+    const bool newComplete = d->m_ui.pathChooser->isValid()
+                             && d->m_ui.packageNameLineEdit->isValid();
     if (newComplete != d->m_complete) {
         d->m_complete = newComplete;
         emit completeChanged();
@@ -198,28 +288,29 @@ void ROSPackageWizardDetailsPage::slotActivated()
 QStringList ROSPackageWizardDetailsPage::processList(const QString &text) const
 {
     QStringList newList;
-    for (const QString& str : text.split(QRegExp(QLatin1String("[,;]")), QString::SkipEmptyParts))
-    {
+    for (const QString &str : text.split(QRegExp(QLatin1String("[,;]")), QString::SkipEmptyParts)) {
         newList.append(QString::fromLatin1("\"%1\"").arg(str.trimmed()));
     }
     return newList;
 }
 
-bool ROSPackageWizardDetailsPage::validateWithValidator(Utils::FancyLineEdit *edit, QString *errorMessage)
+bool ROSPackageWizardDetailsPage::validateWithValidator(Utils::FancyLineEdit *edit,
+                                                        QString *errorMessage)
 {
     const QString path = edit->text();
     if (path.isEmpty()) {
         if (errorMessage)
-            *errorMessage = tr("The path \"%1\" expanded to an empty string.").arg(QDir::toNativeSeparators(path));
+            *errorMessage = tr("The path \"%1\" expanded to an empty string.")
+                                .arg(QDir::toNativeSeparators(path));
         return false;
     }
 
     const QFileInfo fi(path);
 
-    if (!path.startsWith(edit->placeholderText()))
-    {
+    if (!path.startsWith(edit->placeholderText())) {
         if (errorMessage)
-            *errorMessage = tr("The path \"%1\" is not in the workspace.").arg(QDir::toNativeSeparators(path));
+            *errorMessage = tr("The path \"%1\" is not in the workspace.")
+                                .arg(QDir::toNativeSeparators(path));
 
         return false;
     }
@@ -245,24 +336,26 @@ ROSPackageWizard::ROSPackageWizard()
     setFlags(Core::IWizardFactory::PlatformIndependent);
 }
 
-Core::BaseFileWizard *ROSPackageWizard::create(QWidget *parent, const Core::WizardDialogParameters &parameters) const
-{  
+Core::BaseFileWizard *ROSPackageWizard::create(QWidget *parent,
+                                               const Core::WizardDialogParameters &parameters) const
+{
     QString defaultPath = parameters.defaultPath();
 
-    ROSProject *rosProject = qobject_cast<ROSProject *>(ProjectExplorer::ProjectTree::currentProject());
+    ROSProject *rosProject = qobject_cast<ROSProject *>(
+        ProjectExplorer::ProjectTree::currentProject());
 
-    if(!rosProject )
+    if (!rosProject)
         return nullptr;
 
     ROSBuildConfiguration *bc = rosProject->rosBuildConfiguration();
 
-    if( bc )
-    {
-        ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(),
-                                                                           bc->rosBuildSystem(),
-                                                                           bc->project()->distribution());
+    if (bc) {
+        ROSUtils::WorkspaceInfo workspaceInfo
+            = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(),
+                                         bc->rosBuildSystem(),
+                                         bc->project()->distribution());
 
-        if( defaultPath ==  workspaceInfo.path.toString() )
+        if (defaultPath == workspaceInfo.path.toString())
             defaultPath = workspaceInfo.sourcePath.toString();
     }
 
@@ -277,8 +370,7 @@ Core::BaseFileWizard *ROSPackageWizard::create(QWidget *parent, const Core::Wiza
     return m_wizard;
 }
 
-Core::GeneratedFiles ROSPackageWizard::generateFiles(const QWizard *w,
-                                                         QString *errorMessage) const
+Core::GeneratedFiles ROSPackageWizard::generateFiles(const QWizard *w, QString *errorMessage) const
 {
     Q_UNUSED(w);
     Q_UNUSED(errorMessage);
@@ -287,8 +379,10 @@ Core::GeneratedFiles ROSPackageWizard::generateFiles(const QWizard *w,
     Utils::FilePath packagePath = Utils::FilePath::fromString(m_wizard->packagePath());
     Utils::FilePath cmakelistPath = Utils::FilePath::fromString(m_wizard->packagePath());
 
-    packagePath = packagePath.pathAppended(m_wizard->packageName()).pathAppended(QLatin1String("package.xml"));
-    cmakelistPath = cmakelistPath.pathAppended(m_wizard->packageName()).pathAppended(QLatin1String("CMakeLists.txt"));
+    packagePath = packagePath.pathAppended(m_wizard->packageName())
+                      .pathAppended(QLatin1String("package.xml"));
+    cmakelistPath = cmakelistPath.pathAppended(m_wizard->packageName())
+                        .pathAppended(QLatin1String("CMakeLists.txt"));
 
     Core::GeneratedFile generatedPackageFile(packagePath.toString());
     generatedPackageFile.setAttributes(Core::GeneratedFile::CustomGeneratorAttribute);
@@ -305,67 +399,71 @@ Core::GeneratedFiles ROSPackageWizard::generateFiles(const QWizard *w,
 
 bool ROSPackageWizard::writeFiles(const Core::GeneratedFiles &files, QString *errorMessage) const
 {
-  Q_UNUSED(files);
-  Q_UNUSED(errorMessage);
+    Q_UNUSED(files);
+    Q_UNUSED(errorMessage);
 
-  ROSProject *project = static_cast<ROSProject *>(ProjectExplorer::ProjectTree::currentProject());
+    ROSProject *project = static_cast<ROSProject *>(ProjectExplorer::ProjectTree::currentProject());
 
-  QProcess *catkin_create_pkg = new QProcess();
+    QProcess *catkin_create_pkg = new QProcess();
 
-  QString cmd = QLatin1String("catkin_create_pkg");
+    QString cmd = QLatin1String("catkin_create_pkg");
 
-  cmd += QString::fromLatin1(" \"%1\"").arg(m_wizard->packageName());
+    cmd += QString::fromLatin1(" \"%1\"").arg(m_wizard->packageName());
 
-  if (!m_wizard->catkin_dependencies().isEmpty())
-      cmd += m_wizard->catkin_dependencies().join(QLatin1Literal(" ")).insert(0,QLatin1Literal(" "));
+    if (!m_wizard->catkin_dependencies().isEmpty())
+        cmd += m_wizard->catkin_dependencies()
+                   .join(QLatin1Literal(" "))
+                   .insert(0, QLatin1Literal(" "));
 
-  if (!m_wizard->system_dependencies().isEmpty())
-      cmd += m_wizard->system_dependencies().join(QLatin1Literal(" ")).insert(0,QLatin1Literal(" -s "));
+    if (!m_wizard->system_dependencies().isEmpty())
+        cmd += m_wizard->system_dependencies()
+                   .join(QLatin1Literal(" "))
+                   .insert(0, QLatin1Literal(" -s "));
 
-  if (!m_wizard->boost_components().isEmpty())
-      cmd += m_wizard->boost_components().join(QLatin1Literal(" ")).insert(0,QLatin1Literal(" -b "));
+    if (!m_wizard->boost_components().isEmpty())
+        cmd += m_wizard->boost_components()
+                   .join(QLatin1Literal(" "))
+                   .insert(0, QLatin1Literal(" -b "));
 
-  if (!m_wizard->version().isEmpty())
-      cmd += QString::fromLatin1(" -V \"%1\"").arg(m_wizard->version());
+    if (!m_wizard->version().isEmpty())
+        cmd += QString::fromLatin1(" -V \"%1\"").arg(m_wizard->version());
 
-  if (!m_wizard->licenses().isEmpty())
-      cmd += QString::fromLatin1(" -l \"%1\"").arg(m_wizard->licenses());
+    if (!m_wizard->licenses().isEmpty())
+        cmd += QString::fromLatin1(" -l \"%1\"").arg(m_wizard->licenses());
 
-  if (!m_wizard->description().isEmpty())
-      cmd += QString::fromLatin1(" -D \"%1\"").arg(m_wizard->description());
+    if (!m_wizard->description().isEmpty())
+        cmd += QString::fromLatin1(" -D \"%1\"").arg(m_wizard->description());
 
-  if (!m_wizard->authors().isEmpty())
-      cmd += m_wizard->authors().join(QLatin1Literal(" -a ")).insert(0,QLatin1Literal(" -a "));
+    if (!m_wizard->authors().isEmpty())
+        cmd += m_wizard->authors().join(QLatin1Literal(" -a ")).insert(0, QLatin1Literal(" -a "));
 
-  if (!m_wizard->maintainers().isEmpty())
-      cmd += m_wizard->maintainers().join(QLatin1Literal(" -m ")).insert(0,QLatin1Literal(" -m "));
+    if (!m_wizard->maintainers().isEmpty())
+        cmd += m_wizard->maintainers().join(QLatin1Literal(" -m ")).insert(0, QLatin1Literal(" -m "));
 
-  cmd += QString::fromLatin1(" --rosdistro \"%1\"").arg(project->distribution().fileName());
+    cmd += QString::fromLatin1(" --rosdistro \"%1\"").arg(project->distribution().fileName());
 
-  // create package using ros command catkin_create_pkg
-  Utils::FilePath packagePath = Utils::FilePath::fromString(m_wizard->packagePath());
-  catkin_create_pkg->setWorkingDirectory(packagePath.toString());
+    // create package using ros command catkin_create_pkg
+    Utils::FilePath packagePath = Utils::FilePath::fromString(m_wizard->packagePath());
+    catkin_create_pkg->setWorkingDirectory(packagePath.toString());
 
-  ROSUtils::sourceROS(catkin_create_pkg, project->distribution());
-  catkin_create_pkg->start(QLatin1String("bash"), QStringList() << QLatin1String("-c") << cmd);
-  catkin_create_pkg->waitForFinished();
-  bool success;
-  if (catkin_create_pkg->exitStatus() != QProcess::CrashExit)
-  {
-    success = true;
-  }
-  else
-  {
-    Core::MessageManager::write(tr("[ROS Error] Faild to create catkin package."));
-    success = false;
-  }
+    ROSUtils::sourceROS(catkin_create_pkg, project->distribution());
+    catkin_create_pkg->start(QLatin1String("bash"), QStringList() << QLatin1String("-c") << cmd);
+    catkin_create_pkg->waitForFinished();
+    bool success;
+    if (catkin_create_pkg->exitStatus() != QProcess::CrashExit) {
+        success = true;
+    } else {
+        Core::MessageManager::write(tr("[ROS Error] Faild to create catkin package."));
+        success = false;
+    }
 
-  delete catkin_create_pkg;
-  return success;
+    delete catkin_create_pkg;
+    return success;
 }
 
-bool ROSPackageWizard::postGenerateFiles(const QWizard *w, const Core::GeneratedFiles &l,
-                                             QString *errorMessage) const
+bool ROSPackageWizard::postGenerateFiles(const QWizard *w,
+                                         const Core::GeneratedFiles &l,
+                                         QString *errorMessage) const
 {
     Q_UNUSED(w);
     Q_UNUSED(l);

--- a/src/project_manager/ros_package_wizard.h
+++ b/src/project_manager/ros_package_wizard.h
@@ -23,10 +23,10 @@
 
 #include <coreplugin/basefilewizard.h>
 #include <coreplugin/basefilewizardfactory.h>
+#include <utils/fancylineedit.h>
+#include <utils/fileutils.h>
 #include <utils/wizard.h>
 #include <utils/wizardpage.h>
-#include <utils/fileutils.h>
-#include <utils/fancylineedit.h>
 
 #include <QProcess>
 
@@ -36,7 +36,9 @@ namespace Internal {
 class ROSPackageWizardDetailsPage;
 class ROSPackageWizardDetailsPagePrivate;
 
-namespace Ui{ class ROSPackageWizardDetailsPage;}
+namespace Ui {
+class ROSPackageWizardDetailsPage;
+}
 
 class ROSPackageWizardDialog : public Core::BaseFileWizard
 {
@@ -111,13 +113,15 @@ public:
     ROSPackageWizard();
 
 protected:
-    Core::BaseFileWizard *create(QWidget *parent, const Core::WizardDialogParameters &parameters) const;
+    Core::BaseFileWizard *create(QWidget *parent,
+                                 const Core::WizardDialogParameters &parameters) const;
 
     Core::GeneratedFiles generateFiles(const QWizard *w, QString *errorMessage) const override;
 
     bool writeFiles(const Core::GeneratedFiles &files, QString *errorMessage) const override;
 
-    bool postGenerateFiles(const QWizard *w, const Core::GeneratedFiles &l,
+    bool postGenerateFiles(const QWizard *w,
+                           const Core::GeneratedFiles &l,
                            QString *errorMessage) const override;
 
 private:

--- a/src/project_manager/ros_packagexml_parser.cpp
+++ b/src/project_manager/ros_packagexml_parser.cpp
@@ -21,8 +21,8 @@
 
 #include "ros_packagexml_parser.h"
 #include <coreplugin/messagemanager.h>
-#include <QFile>
 #include <QDebug>
+#include <QFile>
 
 namespace ROSProjectManager {
 namespace Internal {
@@ -49,11 +49,13 @@ bool ROSPackageXmlParser::parsePackageXml(const Utils::FilePath &filepath)
         return true;
     }
 
-    Core::MessageManager::write(QObject::tr("[ROS Error] Failed to parse file: %1.").arg(m_packageInfo.filepath.toString()));
+    Core::MessageManager::write(
+        QObject::tr("[ROS Error] Failed to parse file: %1.").arg(m_packageInfo.filepath.toString()));
     return false;
 }
 
-bool ROSPackageXmlParser::parsePackageXml(const Utils::FilePath &filepath, ROSUtils::PackageInfo &packageInfo)
+bool ROSPackageXmlParser::parsePackageXml(const Utils::FilePath &filepath,
+                                          ROSUtils::PackageInfo &packageInfo)
 {
     bool result = parsePackageXml(filepath);
     packageInfo = m_packageInfo;
@@ -214,7 +216,6 @@ ROSUtils::PackageInfo ROSPackageXmlParser::getInfo() const
 {
     return m_packageInfo;
 }
-
 
 } // namespace Internal
 } // namespace ROSProjectManager

--- a/src/project_manager/ros_packagexml_parser.h
+++ b/src/project_manager/ros_packagexml_parser.h
@@ -36,8 +36,7 @@ public:
 
     bool parsePackageXml(const Utils::FilePath &filepath);
 
-    bool parsePackageXml(const Utils::FilePath &filepath,
-                         ROSUtils::PackageInfo &packageInfo);
+    bool parsePackageXml(const Utils::FilePath &filepath, ROSUtils::PackageInfo &packageInfo);
 
     ROSUtils::PackageInfo getInfo() const;
 

--- a/src/project_manager/ros_project.h
+++ b/src/project_manager/ros_project.h
@@ -21,26 +21,26 @@
 #ifndef ROSPROJECT_H
 #define ROSPROJECT_H
 
+#include "ros_build_system.h"
 #include "ros_project_plugin.h"
 #include "ros_utils.h"
-#include "ros_build_system.h"
 
+#include <coreplugin/idocument.h>
+#include <projectexplorer/buildconfiguration.h>
 #include <projectexplorer/project.h>
 #include <projectexplorer/projectnodes.h>
+#include <projectexplorer/rawprojectpart.h>
 #include <projectexplorer/target.h>
 #include <projectexplorer/toolchain.h>
-#include <projectexplorer/buildconfiguration.h>
-#include <coreplugin/idocument.h>
-#include <projectexplorer/rawprojectpart.h>
 
-#include <QFuture>
-#include <QFutureWatcher>
-#include <QFutureInterface>
-#include <QTimer>
 #include <QFileSystemWatcher>
+#include <QFuture>
+#include <QFutureInterface>
+#include <QFutureWatcher>
+#include <QTimer>
 
 namespace CppTools {
-    class CppProjectUpdater;
+class CppProjectUpdater;
 }
 
 namespace ROSProjectManager {
@@ -62,7 +62,7 @@ public:
 
     Utils::FilePath distribution() const;
     ROSUtils::BuildSystem defaultBuildSystem() const;
-    ROSBuildConfiguration* rosBuildConfiguration() const;
+    ROSBuildConfiguration *rosBuildConfiguration() const;
 
     ROSUtils::PackageInfoMap getPackageInfo() const;
     ROSUtils::PackageBuildInfoMap getPackageBuildInfo() const;
@@ -85,8 +85,8 @@ private:
     void updateEnvironment();
 
     ROSUtils::ROSProjectFileContent m_projectFileContent;
-    ROSUtils::PackageInfoMap        m_wsPackageInfo;
-    ROSUtils::PackageBuildInfoMap   m_wsPackageBuildInfo;
+    ROSUtils::PackageInfoMap m_wsPackageInfo;
+    ROSUtils::PackageBuildInfoMap m_wsPackageBuildInfo;
 
     CppTools::CppProjectUpdater *m_cppCodeModelUpdater;
 
@@ -98,20 +98,19 @@ private:
     QStringList m_workspaceDirectories;
     bool m_project_loaded;
 
-
     struct FutureWatcherResults
     {
-      ProjectExplorer::ProjectNode* node;
-      QHash<QString, ROSUtils::FolderContent> workspaceContent;
-      QStringList files;
-      QStringList directories;
+        ProjectExplorer::ProjectNode *node;
+        QHash<QString, ROSUtils::FolderContent> workspaceContent;
+        QStringList files;
+        QStringList directories;
     };
 
     struct CppToolsFutureResults
     {
-      ProjectExplorer::RawProjectParts parts;
-      ROSUtils::PackageInfoMap wsPackageInfo;
-      ROSUtils::PackageBuildInfoMap wsPackageBuildInfo;
+        ProjectExplorer::RawProjectParts parts;
+        ROSUtils::PackageInfoMap wsPackageInfo;
+        ROSUtils::PackageBuildInfoMap wsPackageBuildInfo;
     };
 
     QFutureInterface<FutureWatcherResults> *m_asyncUpdateFutureInterface;
@@ -130,9 +129,8 @@ private:
                                   const ProjectExplorer::Kit *k,
                                   const Utils::Environment &env,
                                   const ROSUtils::PackageInfoMap wsPackageInfo,
-                                  const ROSUtils::PackageBuildInfoMap  wsPackageBuildInfo,
+                                  const ROSUtils::PackageBuildInfoMap wsPackageBuildInfo,
                                   QFutureInterface<CppToolsFutureResults> &fi);
-
 };
 
 } // namespace Internal

--- a/src/project_manager/ros_project_constants.h
+++ b/src/project_manager/ros_project_constants.h
@@ -26,10 +26,10 @@ namespace ROSProjectManager {
 namespace Constants {
 
 // Project
-const char ROS_PROJECT_ID[]  = "ROSProjectManager.ROSProject";
+const char ROS_PROJECT_ID[] = "ROSProjectManager.ROSProject";
 const char ROS_PROJECT_CONTEXT[] = "ROSProject.ProjectContext";
 const char ROS_PROJECT_FILE_ID[] = "ROSProject.ProjectFile";
-const char ROS_MIME_TYPE[]    = "application/ros.project";
+const char ROS_MIME_TYPE[] = "application/ros.project";
 const char ROS_DEFAULT_WORKING_DIR[] = "%{CurrentProject:Path}";
 
 // Tasks
@@ -58,27 +58,25 @@ const char ROS_TEST_ID[] = "ROSProjectManager.ROSTestStep";
 const char ROS_CATKIN_TEST_RESULTS_ID[] = "ROSProjectManager.ROSCatkinTestResultsStep";
 
 // Project Exclude Extension
-const QStringList ROS_EXCLUDE_FILE_EXTENSION = QStringList() << QLatin1Literal("*.autosave") << QLatin1Literal("*.workspace");
+const QStringList ROS_EXCLUDE_FILE_EXTENSION = QStringList() << QLatin1Literal("*.autosave")
+                                                             << QLatin1Literal("*.workspace");
 
 // ROS Cpp Code Style ID
 const char ROS_CPP_CODE_STYLE_ID[] = "ROSProject.CppCodeStyle";
 
 // ROS C++ constants
-const char SOURCE_HEADER_FILE_FILTER[] = "*.c; *.cc; *.cpp; *.c++; *.cp; *.cxx; *.h; *.hh; *.hpp; *.h++; *.hp; *.hxx;";
+const char SOURCE_HEADER_FILE_FILTER[]
+    = "*.c; *.cc; *.cpp; *.c++; *.cp; *.cxx; *.h; *.hh; *.hpp; *.h++; *.hp; *.hxx;";
 
-const QStringList SOURCE_FILE_EXTENSIONS = QStringList() << QLatin1Literal("c")
-                                                         << QLatin1Literal("cc")
-                                                         << QLatin1Literal("cpp")
-                                                         << QLatin1Literal("c++")
-                                                         << QLatin1Literal("cp")
-                                                         << QLatin1Literal("cxx");
+const QStringList SOURCE_FILE_EXTENSIONS = QStringList()
+                                           << QLatin1Literal("c") << QLatin1Literal("cc")
+                                           << QLatin1Literal("cpp") << QLatin1Literal("c++")
+                                           << QLatin1Literal("cp") << QLatin1Literal("cxx");
 
-const QStringList HEADER_FILE_EXTENSIONS = QStringList() << QLatin1Literal("h")
-                                                         << QLatin1Literal("hh")
-                                                         << QLatin1Literal("hpp")
-                                                         << QLatin1Literal("h++")
-                                                         << QLatin1Literal("hp")
-                                                         << QLatin1Literal("hxx");
+const QStringList HEADER_FILE_EXTENSIONS = QStringList()
+                                           << QLatin1Literal("h") << QLatin1Literal("hh")
+                                           << QLatin1Literal("hpp") << QLatin1Literal("h++")
+                                           << QLatin1Literal("hp") << QLatin1Literal("hxx");
 
 // ROS Settings Widgets
 const char ROS_SETTINGS_GROUP_ID[] = "ROSProjectManager.ROSSettingsGroup";

--- a/src/project_manager/ros_project_nodes.cpp
+++ b/src/project_manager/ros_project_nodes.cpp
@@ -21,9 +21,9 @@
 #include "ros_project_nodes.h"
 #include "ros_project_constants.h"
 
-#include <utils/fileutils.h>
 #include <coreplugin/idocument.h>
 #include <projectexplorer/projectexplorer.h>
+#include <utils/fileutils.h>
 
 #include <QFileInfo>
 
@@ -32,25 +32,25 @@ using namespace ProjectExplorer;
 namespace ROSProjectManager {
 namespace Internal {
 
-ROSProjectNode::ROSProjectNode(const Utils::FilePath &projectFilePath) : ProjectNode(projectFilePath)
+ROSProjectNode::ROSProjectNode(const Utils::FilePath &projectFilePath)
+    : ProjectNode(projectFilePath)
 {
     setDisplayName(projectFilePath.toFileInfo().completeBaseName());
 }
 
 FileNode *ROSProjectNode::findFileNode(FolderNode *folder_node, const Utils::FilePath &filePaths)
 {
-  FileNode* file_node = folder_node->fileNode(filePaths);
-  if (file_node)
-      return file_node;
-
-  for (FolderNode *fn : folder_node->folderNodes())
-  {
-    file_node = findFileNode(fn, filePaths);
+    FileNode *file_node = folder_node->fileNode(filePaths);
     if (file_node)
         return file_node;
-  }
 
-  return nullptr;
+    for (FolderNode *fn : folder_node->folderNodes()) {
+        file_node = findFileNode(fn, filePaths);
+        if (file_node)
+            return file_node;
+    }
+
+    return nullptr;
 }
 
 bool ROSProjectNode::showInSimpleTree() const
@@ -58,14 +58,14 @@ bool ROSProjectNode::showInSimpleTree() const
     return true;
 }
 
-ROSFolderNode::ROSFolderNode(const Utils::FilePath &folderPath) : FolderNode(folderPath), m_repository(nullptr)
+ROSFolderNode::ROSFolderNode(const Utils::FilePath &folderPath)
+    : FolderNode(folderPath)
+    , m_repository(nullptr)
 {
     QString path = this->filePath().toString();
 
-    if (Core::IVersionControl *vc = Core::VcsManager::findVersionControlForDirectory(path))
-    {
-        if (path == Core::VcsManager::findTopLevelForDirectory(path))
-        {
+    if (Core::IVersionControl *vc = Core::VcsManager::findVersionControlForDirectory(path)) {
+        if (path == Core::VcsManager::findTopLevelForDirectory(path)) {
             m_repository = vc;
         }
     }
@@ -73,14 +73,11 @@ ROSFolderNode::ROSFolderNode(const Utils::FilePath &folderPath) : FolderNode(fol
 
 QString ROSFolderNode::displayName() const
 {
-    if (m_repository)
-    {
+    if (m_repository) {
         QString path = this->filePath().toString();
         QString name = Utils::FilePath::fromString(path).fileName();
         return QString::fromLatin1("%1 [%2]").arg(name, m_repository->vcsTopic(path));
-    }
-    else
-    {
+    } else {
         return this->FolderNode::displayName();
     }
 }

--- a/src/project_manager/ros_project_nodes.h
+++ b/src/project_manager/ros_project_nodes.h
@@ -21,17 +21,19 @@
 #ifndef ROSPROJECTNODE_H
 #define ROSPROJECTNODE_H
 
-#include <projectexplorer/projectnodes.h>
-#include <coreplugin/vcsmanager.h>
 #include <coreplugin/iversioncontrol.h>
+#include <coreplugin/vcsmanager.h>
+#include <projectexplorer/projectnodes.h>
 
 #include "ros_utils.h"
 
-#include <QStringList>
 #include <QHash>
 #include <QSet>
+#include <QStringList>
 
-namespace Core { class IDocument; }
+namespace Core {
+class IDocument;
+}
 
 namespace ROSProjectManager {
 namespace Internal {
@@ -44,11 +46,12 @@ public:
     bool showInSimpleTree() const override;
 
 private:
-    static ProjectExplorer::FileNode *findFileNode(FolderNode *folder_node, const Utils::FilePath &filePaths);
+    static ProjectExplorer::FileNode *findFileNode(FolderNode *folder_node,
+                                                   const Utils::FilePath &filePaths);
 };
 typedef std::unique_ptr<ROSProjectNode> ROSProjectNodeUPtr;
 
-class ROSFolderNode: public ProjectExplorer::FolderNode
+class ROSFolderNode : public ProjectExplorer::FolderNode
 {
 public:
     explicit ROSFolderNode(const Utils::FilePath &folderPath);

--- a/src/project_manager/ros_project_plugin.cpp
+++ b/src/project_manager/ros_project_plugin.cpp
@@ -19,65 +19,64 @@
  * limitations under the License.
  */
 #include "ros_project_plugin.h"
-#include "ros_terminal_pane.h"
+#include "remove_directory_dialog.h"
 #include "ros_build_configuration.h"
-#include "ros_run_configuration.h"
-#include "ros_rosrun_step.h"
-#include "ros_roslaunch_step.h"
-#include "ros_rosattach_step.h"
-#include "ros_rostest_step.h"
-#include "ros_catkin_test_results_step.h"
-#include "ros_project_wizard.h"
-#include "ros_project_constants.h"
 #include "ros_catkin_make_step.h"
+#include "ros_catkin_test_results_step.h"
 #include "ros_catkin_tools_step.h"
 #include "ros_colcon_step.h"
-#include "ros_project.h"
-#include "ros_utils.h"
-#include "ros_project_constants.h"
 #include "ros_package_wizard.h"
+#include "ros_project.h"
+#include "ros_project_constants.h"
+#include "ros_project_wizard.h"
+#include "ros_rosattach_step.h"
+#include "ros_roslaunch_step.h"
+#include "ros_rosrun_step.h"
+#include "ros_rostest_step.h"
+#include "ros_run_configuration.h"
 #include "ros_settings_page.h"
-#include "remove_directory_dialog.h"
+#include "ros_terminal_pane.h"
+#include "ros_utils.h"
 
-#include <coreplugin/icore.h>
-#include <coreplugin/actionmanager/actionmanager.h>
 #include <coreplugin/actionmanager/actioncontainer.h>
+#include <coreplugin/actionmanager/actionmanager.h>
 #include <coreplugin/actionmanager/command.h>
+#include <coreplugin/icore.h>
 #include <coreplugin/progressmanager/progressmanager.h>
 
 #include <cpptools/cppcodestylepreferences.h>
-#include <cpptools/cpptoolssettings.h>
 #include <cpptools/cpptoolsconstants.h>
+#include <cpptools/cpptoolssettings.h>
 
 #include <texteditor/codestylepool.h>
 #include <texteditor/tabsettings.h>
 #include <texteditor/texteditorsettings.h>
 
-#include <projectexplorer/projectmanager.h>
-#include <projectexplorer/projectexplorerconstants.h>
-#include <projectexplorer/projecttree.h>
-#include <projectexplorer/selectablefilesmodel.h>
-#include <projectexplorer/gnumakeparser.h>
-#include <projectexplorer/buildsteplist.h>
-#include <projectexplorer/projectexplorer.h>
+#include <projectexplorer/appoutputpane.h>
 #include <projectexplorer/buildmanager.h>
 #include <projectexplorer/buildstep.h>
+#include <projectexplorer/buildsteplist.h>
 #include <projectexplorer/compileoutputwindow.h>
-#include <projectexplorer/appoutputpane.h>
+#include <projectexplorer/gnumakeparser.h>
+#include <projectexplorer/projectexplorer.h>
+#include <projectexplorer/projectexplorerconstants.h>
+#include <projectexplorer/projectmanager.h>
+#include <projectexplorer/projecttree.h>
 #include <projectexplorer/projecttreewidget.h>
+#include <projectexplorer/selectablefilesmodel.h>
 
-#include <extensionsystem/pluginmanager.h>
 #include <extensionsystem/invoker.h>
+#include <extensionsystem/pluginmanager.h>
 
 #include <utils/algorithm.h>
 #include <utils/fileutils.h>
 #include <utils/mimetypes/mimedatabase.h>
 #include <utils/removefiledialog.h>
 
-#include <QtPlugin>
-#include <QDebug>
 #include <QApplication>
+#include <QDebug>
 #include <QMessageBox>
+#include <QtPlugin>
 
 using namespace Core;
 using namespace ProjectExplorer;
@@ -90,11 +89,11 @@ static ROSProjectPlugin *m_instance = nullptr;
 class ROSProjectPluginPrivate
 {
 public:
-    ROSProjectPluginPrivate() :
-      settings(new ROSSettings()),
-      settingsPage(new ROSSettingsPage(settings))
+    ROSProjectPluginPrivate()
+        : settings(new ROSSettings())
+        , settingsPage(new ROSSettingsPage(settings))
     {
-      settings->fromSettings(ICore::settings());
+        settings->fromSettings(ICore::settings());
     }
 
     ROSRunConfigurationFactory runConfigFactory;
@@ -115,16 +114,17 @@ public:
     QSharedPointer<ROSSettingsPage> settingsPage;
 };
 
-ROSProjectPlugin::ROSProjectPlugin() : ExtensionSystem::IPlugin()
+ROSProjectPlugin::ROSProjectPlugin()
+    : ExtensionSystem::IPlugin()
 {
-  m_instance = this;
+    m_instance = this;
 }
 
 ROSProjectPlugin::~ROSProjectPlugin()
 {
-  ExtensionSystem::PluginManager::removeObject(&(d->terminalPane));
-  delete d;
-  m_instance = nullptr;
+    ExtensionSystem::PluginManager::removeObject(&(d->terminalPane));
+    delete d;
+    m_instance = nullptr;
 }
 
 ROSProjectPlugin *ROSProjectPlugin::instance()
@@ -144,16 +144,20 @@ bool ROSProjectPlugin::initialize(const QStringList &, QString *errorMessage)
     if (mimeFilePath.open(QIODevice::ReadOnly)) {
         QByteArray mimeByteArray = mimeFilePath.readAll();
 
-        if( ! mimeByteArray.isEmpty() )
+        if (!mimeByteArray.isEmpty())
             Utils::addMimeTypes(Constants::ROS_MIME_TYPE, mimeByteArray);
-        else { Q_ASSERT(false); }
+        else {
+            Q_ASSERT(false);
+        }
     }
 
     ProjectManager::registerProjectType<ROSProject>(Constants::ROS_MIME_TYPE);
 
-    IWizardFactory::registerFactoryCreator([]() { return QList<IWizardFactory *>() << new ROSProjectWizard << new ROSPackageWizard; });
+    IWizardFactory::registerFactoryCreator(
+        []() { return QList<IWizardFactory *>() << new ROSProjectWizard << new ROSPackageWizard; });
 
-    ActionContainer *mproject = ActionManager::actionContainer(ProjectExplorer::Constants::M_PROJECTCONTEXT);
+    ActionContainer *mproject = ActionManager::actionContainer(
+        ProjectExplorer::Constants::M_PROJECTCONTEXT);
 
     auto reloadProjectBuildInfoAction = new QAction(tr("Reload Project Build Info..."), this);
     Command *reloadCommand = ActionManager::registerAction(reloadProjectBuildInfoAction,
@@ -162,10 +166,14 @@ bool ROSProjectPlugin::initialize(const QStringList &, QString *errorMessage)
 
     reloadCommand->setAttribute(Command::CA_Hide);
     mproject->addAction(reloadCommand, ProjectExplorer::Constants::G_PROJECT_FILES);
-    connect(reloadProjectBuildInfoAction, &QAction::triggered, this, &ROSProjectPlugin::reloadProjectBuildInfo);
+    connect(reloadProjectBuildInfoAction,
+            &QAction::triggered,
+            this,
+            &ROSProjectPlugin::reloadProjectBuildInfo);
 
     // This will context menu action for deleting and renaming project folders from the ProjectTree.
-    ActionContainer *mfolderContextMenu = ActionManager::actionContainer(ProjectExplorer::Constants::M_FOLDERCONTEXT);
+    ActionContainer *mfolderContextMenu = ActionManager::actionContainer(
+        ProjectExplorer::Constants::M_FOLDERCONTEXT);
 
     auto removeProjectDirectoryAction = new QAction(tr("Remove Directory..."), this);
     Command *removeCommand = ActionManager::registerAction(removeProjectDirectoryAction,
@@ -173,7 +181,10 @@ bool ROSProjectPlugin::initialize(const QStringList &, QString *errorMessage)
                                                            Context(Constants::ROS_PROJECT_CONTEXT));
     removeCommand->setAttribute(Command::CA_Hide);
     mfolderContextMenu->addAction(removeCommand, ProjectExplorer::Constants::G_FOLDER_FILES);
-    connect(removeProjectDirectoryAction, &QAction::triggered, this, &ROSProjectPlugin::removeProjectDirectory);
+    connect(removeProjectDirectoryAction,
+            &QAction::triggered,
+            this,
+            &ROSProjectPlugin::removeProjectDirectory);
 
     auto renameFileAction = new QAction(tr("Rename File..."), this);
     Command *renameCommand = ActionManager::registerAction(renameFileAction,
@@ -191,7 +202,7 @@ bool ROSProjectPlugin::initialize(const QStringList &, QString *errorMessage)
 
 QTermWidget &ROSProjectPlugin::startTerminal(int startnow, const QString name)
 {
-  return d->terminalPane.startTerminal(startnow, name);
+    return d->terminalPane.startTerminal(startnow, name);
 }
 
 QSharedPointer<ROSSettings> ROSProjectPlugin::settings() const
@@ -201,51 +212,55 @@ QSharedPointer<ROSSettings> ROSProjectPlugin::settings() const
 
 void ROSProjectPlugin::createCppCodeStyle()
 {
-  TextEditor::CodeStylePool *pool = TextEditor::TextEditorSettings::codeStylePool(CppTools::Constants::CPP_SETTINGS_ID);
+    TextEditor::CodeStylePool *pool = TextEditor::TextEditorSettings::codeStylePool(
+        CppTools::Constants::CPP_SETTINGS_ID);
 
-  // ROS style
-  CppTools::CppCodeStylePreferences *rosCodeStyle = new CppTools::CppCodeStylePreferences();
-  rosCodeStyle->setId(Constants::ROS_CPP_CODE_STYLE_ID);
-  rosCodeStyle->setDisplayName(tr("ROS"));
-  rosCodeStyle->setReadOnly(true);
+    // ROS style
+    CppTools::CppCodeStylePreferences *rosCodeStyle = new CppTools::CppCodeStylePreferences();
+    rosCodeStyle->setId(Constants::ROS_CPP_CODE_STYLE_ID);
+    rosCodeStyle->setDisplayName(tr("ROS"));
+    rosCodeStyle->setReadOnly(true);
 
-  TextEditor::TabSettings rosTabSettings;
-  rosTabSettings.m_tabPolicy = TextEditor::TabSettings::SpacesOnlyTabPolicy;
-  rosTabSettings.m_tabSize = 2;
-  rosTabSettings.m_indentSize = 2;
-  rosTabSettings.m_continuationAlignBehavior = TextEditor::TabSettings::ContinuationAlignWithIndent;
-  rosCodeStyle->setTabSettings(rosTabSettings);
+    TextEditor::TabSettings rosTabSettings;
+    rosTabSettings.m_tabPolicy = TextEditor::TabSettings::SpacesOnlyTabPolicy;
+    rosTabSettings.m_tabSize = 2;
+    rosTabSettings.m_indentSize = 2;
+    rosTabSettings.m_continuationAlignBehavior = TextEditor::TabSettings::ContinuationAlignWithIndent;
+    rosCodeStyle->setTabSettings(rosTabSettings);
 
-  CppTools::CppCodeStyleSettings rosCodeStyleSettings;
-  rosCodeStyleSettings.alignAssignments = false;
-  rosCodeStyleSettings.bindStarToIdentifier = true;
-  rosCodeStyleSettings.bindStarToLeftSpecifier = false;
-  rosCodeStyleSettings.bindStarToRightSpecifier = false;
-  rosCodeStyleSettings.bindStarToTypeName = false;
-  rosCodeStyleSettings.extraPaddingForConditionsIfConfusingAlign = true;
-  rosCodeStyleSettings.indentAccessSpecifiers = false;
-  rosCodeStyleSettings.indentBlockBody = true;
-  rosCodeStyleSettings.indentBlockBraces = false;
-  rosCodeStyleSettings.indentBlocksRelativeToSwitchLabels = false;
-  rosCodeStyleSettings.indentClassBraces = false;
-  rosCodeStyleSettings.indentControlFlowRelativeToSwitchLabels = true;
-  rosCodeStyleSettings.indentDeclarationsRelativeToAccessSpecifiers = true;
-  rosCodeStyleSettings.indentEnumBraces = false;
-  rosCodeStyleSettings.indentFunctionBody = true;
-  rosCodeStyleSettings.indentFunctionBraces = false;
-  rosCodeStyleSettings.indentNamespaceBody = false;
-  rosCodeStyleSettings.indentNamespaceBraces = false;
-  rosCodeStyleSettings.indentStatementsRelativeToSwitchLabels = true;
-  rosCodeStyleSettings.indentSwitchLabels = false;
-  rosCodeStyle->setCodeStyleSettings(rosCodeStyleSettings);
+    CppTools::CppCodeStyleSettings rosCodeStyleSettings;
+    rosCodeStyleSettings.alignAssignments = false;
+    rosCodeStyleSettings.bindStarToIdentifier = true;
+    rosCodeStyleSettings.bindStarToLeftSpecifier = false;
+    rosCodeStyleSettings.bindStarToRightSpecifier = false;
+    rosCodeStyleSettings.bindStarToTypeName = false;
+    rosCodeStyleSettings.extraPaddingForConditionsIfConfusingAlign = true;
+    rosCodeStyleSettings.indentAccessSpecifiers = false;
+    rosCodeStyleSettings.indentBlockBody = true;
+    rosCodeStyleSettings.indentBlockBraces = false;
+    rosCodeStyleSettings.indentBlocksRelativeToSwitchLabels = false;
+    rosCodeStyleSettings.indentClassBraces = false;
+    rosCodeStyleSettings.indentControlFlowRelativeToSwitchLabels = true;
+    rosCodeStyleSettings.indentDeclarationsRelativeToAccessSpecifiers = true;
+    rosCodeStyleSettings.indentEnumBraces = false;
+    rosCodeStyleSettings.indentFunctionBody = true;
+    rosCodeStyleSettings.indentFunctionBraces = false;
+    rosCodeStyleSettings.indentNamespaceBody = false;
+    rosCodeStyleSettings.indentNamespaceBraces = false;
+    rosCodeStyleSettings.indentStatementsRelativeToSwitchLabels = true;
+    rosCodeStyleSettings.indentSwitchLabels = false;
+    rosCodeStyle->setCodeStyleSettings(rosCodeStyleSettings);
 
-  pool->addCodeStyle(rosCodeStyle);
+    pool->addCodeStyle(rosCodeStyle);
 
-  // Since the ROS Cpp code style can not be added until after the CppToolsSettings instance is create
-  // the Cpp code style must be reloaded from settings to capture if it is set ROS Cpp code style.
-  QSettings *s = Core::ICore::settings();
-  CppTools::CppCodeStylePreferences *originalCppCodeStylePreferences = CppTools::CppToolsSettings::instance()->cppCodeStyle();
-  originalCppCodeStylePreferences->fromSettings(QLatin1String(CppTools::Constants::CPP_SETTINGS_ID), s);
+    // Since the ROS Cpp code style can not be added until after the CppToolsSettings instance is create
+    // the Cpp code style must be reloaded from settings to capture if it is set ROS Cpp code style.
+    QSettings *s = Core::ICore::settings();
+    CppTools::CppCodeStylePreferences *originalCppCodeStylePreferences
+        = CppTools::CppToolsSettings::instance()->cppCodeStyle();
+    originalCppCodeStylePreferences->fromSettings(QLatin1String(
+                                                      CppTools::Constants::CPP_SETTINGS_ID),
+                                                  s);
 }
 
 void ROSProjectPlugin::reloadProjectBuildInfo()
@@ -256,19 +271,18 @@ void ROSProjectPlugin::reloadProjectBuildInfo()
 
 void ROSProjectPlugin::removeProjectDirectory()
 {
-  ProjectExplorer::Node *currentNode = ProjectExplorer::ProjectTree::currentNode();
+    ProjectExplorer::Node *currentNode = ProjectExplorer::ProjectTree::currentNode();
 
-  QTC_ASSERT(currentNode && currentNode->isFolderNodeType(), return);
+    QTC_ASSERT(currentNode && currentNode->isFolderNodeType(), return );
 
-  QString filePath = currentNode->filePath().toString();
-  RemoveDirectoryDialog removeDirectoryDialog(filePath, ICore::mainWindow());
+    QString filePath = currentNode->filePath().toString();
+    RemoveDirectoryDialog removeDirectoryDialog(filePath, ICore::mainWindow());
 
-  if (removeDirectoryDialog.exec() == QDialog::Accepted)
-  {
-      const bool deleteDirectory = removeDirectoryDialog.isDeleteDirectoryChecked();
-      if (deleteDirectory)
-          QDir(filePath).removeRecursively();
-  }
+    if (removeDirectoryDialog.exec() == QDialog::Accepted) {
+        const bool deleteDirectory = removeDirectoryDialog.isDeleteDirectoryChecked();
+        if (deleteDirectory)
+            QDir(filePath).removeRecursively();
+    }
 }
 
 void ROSProjectPlugin::renameFile()

--- a/src/project_manager/ros_project_plugin.h
+++ b/src/project_manager/ros_project_plugin.h
@@ -21,14 +21,14 @@
 #ifndef ROSPROJECTPLUGIN_H
 #define ROSPROJECTPLUGIN_H
 #include <extensionsystem/iplugin.h>
-#include <QObject>
 #include <QAction>
+#include <QObject>
 #include <qtermwidget5/qtermwidget.h>
 
 namespace ProjectExplorer {
 class Project;
 class Node;
-}
+} // namespace ProjectExplorer
 
 namespace ROSProjectManager {
 namespace Internal {
@@ -82,14 +82,12 @@ private slots:
     void renameFile();
 
 private:
-
     /**
      * @brief This creates a built-in ROS Cpp code style.
      */
     void createCppCodeStyle();
 
     class ROSProjectPluginPrivate *d = nullptr;
-
 };
 
 } // namespace Internal

--- a/src/project_manager/ros_project_wizard.h
+++ b/src/project_manager/ros_project_wizard.h
@@ -25,9 +25,9 @@
 
 #include <coreplugin/basefilewizard.h>
 #include <coreplugin/basefilewizardfactory.h>
+#include <utils/fileutils.h>
 #include <utils/wizard.h>
 #include <utils/wizardpage.h>
-#include <utils/fileutils.h>
 
 #include <QProcess>
 
@@ -35,7 +35,9 @@ namespace ROSProjectManager {
 namespace Internal {
 class ROSImportWizardPage;
 class ROSImportWizardPagePrivate;
-namespace Ui{ class ROSImportWizardPage;}
+namespace Ui {
+class ROSImportWizardPage;
+}
 class ROSProjectWizardDialog : public Core::BaseFileWizard
 {
     Q_OBJECT
@@ -79,15 +81,14 @@ private slots:
     void slotProjectNameValidChanged();
     void slotProjectPathValidChanged();
     void slotActivated();
-//    void slotUpdateStdError();
-//    void slotUpdateStdText();
+    //    void slotUpdateStdError();
+    //    void slotUpdateStdText();
 
 private:
     ROSImportWizardPagePrivate *d;
 
     void validChangedHelper();
 };
-
 
 class ROSProjectWizard : public Core::BaseFileWizardFactory
 {
@@ -97,9 +98,11 @@ public:
     ROSProjectWizard();
 
 protected:
-    Core::BaseFileWizard *create(QWidget *parent, const Core::WizardDialogParameters &parameters) const override;
+    Core::BaseFileWizard *create(QWidget *parent,
+                                 const Core::WizardDialogParameters &parameters) const override;
     Core::GeneratedFiles generateFiles(const QWizard *w, QString *errorMessage) const override;
-    bool postGenerateFiles(const QWizard *w, const Core::GeneratedFiles &l,
+    bool postGenerateFiles(const QWizard *w,
+                           const Core::GeneratedFiles &l,
                            QString *errorMessage) const override;
 };
 

--- a/src/project_manager/ros_rosattach_step.cpp
+++ b/src/project_manager/ros_rosattach_step.cpp
@@ -20,50 +20,51 @@
  */
 
 #include "ros_rosattach_step.h"
-#include "ros_utils.h"
 #include "ros_build_configuration.h"
+#include "ros_utils.h"
 
 namespace ROSProjectManager {
 namespace Internal {
 
-ROSAttachStep::ROSAttachStep(RunStepList *rsl) : ROSGenericRunStep(rsl, Constants::ROS_ATTACH_TO_NODE_ID)
+ROSAttachStep::ROSAttachStep(RunStepList *rsl)
+    : ROSGenericRunStep(rsl, Constants::ROS_ATTACH_TO_NODE_ID)
 {
-  ctor();
+    ctor();
 }
 
-ROSAttachStep::ROSAttachStep(RunStepList *rsl, Utils::Id id) : ROSGenericRunStep(rsl, id)
+ROSAttachStep::ROSAttachStep(RunStepList *rsl, Utils::Id id)
+    : ROSGenericRunStep(rsl, id)
 {
-  ctor();
+    ctor();
 }
 
-void ROSAttachStep::run()
-{
-}
+void ROSAttachStep::run() {}
 
 void ROSAttachStep::ctor()
 {
-  setCommand("debug");
+    setCommand("debug");
 }
 
 RunStepConfigWidget *ROSAttachStep::createConfigWidget()
 {
-  return new ROSGenericRunStepConfigWidget(this, true, false, true);
+    return new ROSGenericRunStepConfigWidget(this, true, false, true);
 }
 
 QMap<QString, QString> ROSAttachStep::getAvailableTargets()
 {
-  ROSBuildConfiguration *bc = qobject_cast<ROSBuildConfiguration *>(target()->activeBuildConfiguration());
-  return ROSUtils::getROSPackageExecutables(getPackage(), bc->environment().toStringList());
+    ROSBuildConfiguration *bc = qobject_cast<ROSBuildConfiguration *>(
+        target()->activeBuildConfiguration());
+    return ROSUtils::getROSPackageExecutables(getPackage(), bc->environment().toStringList());
 }
 
-ROSAttachStepFactory::ROSAttachStepFactory() :
-    RunStepFactory()
+ROSAttachStepFactory::ROSAttachStepFactory()
+    : RunStepFactory()
 {
-  registerStep<ROSAttachStep>(Constants::ROS_ATTACH_TO_NODE_ID);
-  setDisplayName("ROS Attach to Node Step");
-  setFlags(RunStepInfo::Flags::UniqueStep);
-  setSupportedProjectType(Constants::ROS_PROJECT_ID);
-  setSupportedStepList(Constants::ROS_RUN_STEP_LIST_ID);
+    registerStep<ROSAttachStep>(Constants::ROS_ATTACH_TO_NODE_ID);
+    setDisplayName("ROS Attach to Node Step");
+    setFlags(RunStepInfo::Flags::UniqueStep);
+    setSupportedProjectType(Constants::ROS_PROJECT_ID);
+    setSupportedStepList(Constants::ROS_RUN_STEP_LIST_ID);
 }
 
 } // namespace Internal

--- a/src/project_manager/ros_rosattach_step.h
+++ b/src/project_manager/ros_rosattach_step.h
@@ -26,27 +26,28 @@
 namespace ROSProjectManager {
 namespace Internal {
 
-namespace Ui { class ROSGenericStep; }
+namespace Ui {
+class ROSGenericStep;
+}
 
 class ROSAttachStep : public ROSGenericRunStep
 {
-  Q_OBJECT
-  friend class ROSAttachStepFactory;
+    Q_OBJECT
+    friend class ROSAttachStepFactory;
 
 public:
-  ROSAttachStep(RunStepList *rsl);
+    ROSAttachStep(RunStepList *rsl);
 
-  void run() override;
+    void run() override;
 
 protected:
-  ROSAttachStep(RunStepList *rsl, Utils::Id id);
+    ROSAttachStep(RunStepList *rsl, Utils::Id id);
 
-  void ctor();
+    void ctor();
 
-  RunStepConfigWidget *createConfigWidget() override;
+    RunStepConfigWidget *createConfigWidget() override;
 
-  QMap<QString, QString> getAvailableTargets() override;
-
+    QMap<QString, QString> getAvailableTargets() override;
 };
 
 class ROSAttachStepFactory : public RunStepFactory
@@ -55,6 +56,6 @@ public:
     ROSAttachStepFactory();
 };
 
-} // Internal
-} // ROSProjectManager
+} // namespace Internal
+} // namespace ROSProjectManager
 #endif // ROS_ROSATTACH_STEP_H

--- a/src/project_manager/ros_roslaunch_step.cpp
+++ b/src/project_manager/ros_roslaunch_step.cpp
@@ -25,38 +25,40 @@
 namespace ROSProjectManager {
 namespace Internal {
 
-ROSLaunchStep::ROSLaunchStep(RunStepList *rsl) : ROSGenericRunStep(rsl, Constants::ROS_LAUNCH_ID)
+ROSLaunchStep::ROSLaunchStep(RunStepList *rsl)
+    : ROSGenericRunStep(rsl, Constants::ROS_LAUNCH_ID)
 {
-  ctor();
+    ctor();
 }
 
-ROSLaunchStep::ROSLaunchStep(RunStepList *rsl, Utils::Id id) : ROSGenericRunStep(rsl, id)
+ROSLaunchStep::ROSLaunchStep(RunStepList *rsl, Utils::Id id)
+    : ROSGenericRunStep(rsl, id)
 {
-  ctor();
+    ctor();
 }
 
 RunStepConfigWidget *ROSLaunchStep::createConfigWidget()
 {
-  return new ROSGenericRunStepConfigWidget(this, true, true, false);
+    return new ROSGenericRunStepConfigWidget(this, true, true, false);
 }
 
 QMap<QString, QString> ROSLaunchStep::getAvailableTargets()
 {
-  return ROSUtils::getROSPackageLaunchFiles(getPackagePath());
+    return ROSUtils::getROSPackageLaunchFiles(getPackagePath());
 }
 
 void ROSLaunchStep::ctor()
 {
-  setCommand("roslaunch");
+    setCommand("roslaunch");
 }
 
-ROSLaunchStepFactory::ROSLaunchStepFactory() :
-    RunStepFactory()
+ROSLaunchStepFactory::ROSLaunchStepFactory()
+    : RunStepFactory()
 {
-  registerStep<ROSLaunchStep>(Constants::ROS_LAUNCH_ID);
-  setDisplayName("ROS Launch Step");
-  setSupportedProjectType(Constants::ROS_PROJECT_ID);
-  setSupportedStepList(Constants::ROS_RUN_STEP_LIST_ID);
+    registerStep<ROSLaunchStep>(Constants::ROS_LAUNCH_ID);
+    setDisplayName("ROS Launch Step");
+    setSupportedProjectType(Constants::ROS_PROJECT_ID);
+    setSupportedStepList(Constants::ROS_RUN_STEP_LIST_ID);
 }
 
 } // namespace Internal

--- a/src/project_manager/ros_roslaunch_step.h
+++ b/src/project_manager/ros_roslaunch_step.h
@@ -26,25 +26,26 @@
 namespace ROSProjectManager {
 namespace Internal {
 
-namespace Ui { class ROSGenericStep; }
+namespace Ui {
+class ROSGenericStep;
+}
 
 class ROSLaunchStep : public ROSGenericRunStep
 {
-  Q_OBJECT
-  friend class ROSLaunchStepFactory;
+    Q_OBJECT
+    friend class ROSLaunchStepFactory;
 
 public:
-  ROSLaunchStep(RunStepList *rsl);
+    ROSLaunchStep(RunStepList *rsl);
 
 protected:
-  ROSLaunchStep(RunStepList *rsl, Utils::Id id);
+    ROSLaunchStep(RunStepList *rsl, Utils::Id id);
 
-  void ctor();
+    void ctor();
 
-  RunStepConfigWidget *createConfigWidget() override;
+    RunStepConfigWidget *createConfigWidget() override;
 
-  QMap<QString, QString> getAvailableTargets() override;
-
+    QMap<QString, QString> getAvailableTargets() override;
 };
 
 class ROSLaunchStepFactory : public RunStepFactory
@@ -53,6 +54,6 @@ public:
     ROSLaunchStepFactory();
 };
 
-} // Internal
-} // ROSProjectManager
+} // namespace Internal
+} // namespace ROSProjectManager
 #endif // ROS_ROSLAUNCH_STEP_H

--- a/src/project_manager/ros_rosrun_step.cpp
+++ b/src/project_manager/ros_rosrun_step.cpp
@@ -20,45 +20,48 @@
  */
 
 #include "ros_rosrun_step.h"
-#include "ros_utils.h"
 #include "ros_build_configuration.h"
+#include "ros_utils.h"
 
 namespace ROSProjectManager {
 namespace Internal {
 
-ROSRunStep::ROSRunStep(RunStepList *rsl) : ROSGenericRunStep(rsl, Constants::ROS_RUN_ID)
+ROSRunStep::ROSRunStep(RunStepList *rsl)
+    : ROSGenericRunStep(rsl, Constants::ROS_RUN_ID)
 {
-  ctor();
+    ctor();
 }
 
-ROSRunStep::ROSRunStep(RunStepList *rsl, Utils::Id id) : ROSGenericRunStep(rsl, id)
+ROSRunStep::ROSRunStep(RunStepList *rsl, Utils::Id id)
+    : ROSGenericRunStep(rsl, id)
 {
-  ctor();
+    ctor();
 }
 
 void ROSRunStep::ctor()
 {
-  setCommand("rosrun");
+    setCommand("rosrun");
 }
 
 RunStepConfigWidget *ROSRunStep::createConfigWidget()
 {
-  return new ROSGenericRunStepConfigWidget(this, true, true, false);
+    return new ROSGenericRunStepConfigWidget(this, true, true, false);
 }
 
 QMap<QString, QString> ROSRunStep::getAvailableTargets()
 {
-  ROSBuildConfiguration *bc = qobject_cast<ROSBuildConfiguration *>(target()->activeBuildConfiguration());
-  return ROSUtils::getROSPackageExecutables(getPackage(), bc->environment().toStringList());
+    ROSBuildConfiguration *bc = qobject_cast<ROSBuildConfiguration *>(
+        target()->activeBuildConfiguration());
+    return ROSUtils::getROSPackageExecutables(getPackage(), bc->environment().toStringList());
 }
 
-ROSRunStepFactory::ROSRunStepFactory() :
-    RunStepFactory()
+ROSRunStepFactory::ROSRunStepFactory()
+    : RunStepFactory()
 {
-  registerStep<ROSRunStep>(Constants::ROS_RUN_ID);
-  setDisplayName("ROS Run Step");
-  setSupportedProjectType(Constants::ROS_PROJECT_ID);
-  setSupportedStepList(Constants::ROS_RUN_STEP_LIST_ID);
+    registerStep<ROSRunStep>(Constants::ROS_RUN_ID);
+    setDisplayName("ROS Run Step");
+    setSupportedProjectType(Constants::ROS_PROJECT_ID);
+    setSupportedStepList(Constants::ROS_RUN_STEP_LIST_ID);
 }
 
 } // namespace Internal

--- a/src/project_manager/ros_rosrun_step.h
+++ b/src/project_manager/ros_rosrun_step.h
@@ -26,25 +26,26 @@
 namespace ROSProjectManager {
 namespace Internal {
 
-namespace Ui { class ROSGenericStep; }
+namespace Ui {
+class ROSGenericStep;
+}
 
 class ROSRunStep : public ROSGenericRunStep
 {
-  Q_OBJECT
-  friend class ROSRunStepFactory;
+    Q_OBJECT
+    friend class ROSRunStepFactory;
 
 public:
-  ROSRunStep(RunStepList *rsl);
+    ROSRunStep(RunStepList *rsl);
 
 protected:
-  ROSRunStep(RunStepList *rsl, Utils::Id id);
+    ROSRunStep(RunStepList *rsl, Utils::Id id);
 
-  void ctor();
+    void ctor();
 
-  RunStepConfigWidget *createConfigWidget() override;
+    RunStepConfigWidget *createConfigWidget() override;
 
-  QMap<QString, QString> getAvailableTargets() override;
-
+    QMap<QString, QString> getAvailableTargets() override;
 };
 
 class ROSRunStepFactory : public RunStepFactory
@@ -53,6 +54,6 @@ public:
     ROSRunStepFactory();
 };
 
-} // Internal
-} // ROSProjectManager
+} // namespace Internal
+} // namespace ROSProjectManager
 #endif // ROS_ROSRUN_STEP_H

--- a/src/project_manager/ros_rostest_step.cpp
+++ b/src/project_manager/ros_rostest_step.cpp
@@ -20,45 +20,48 @@
  */
 
 #include "ros_rostest_step.h"
-#include "ros_utils.h"
 #include "ros_build_configuration.h"
+#include "ros_utils.h"
 
 namespace ROSProjectManager {
 namespace Internal {
 
-ROSTestStep::ROSTestStep(RunStepList *rsl) : ROSGenericRunStep(rsl, Constants::ROS_TEST_ID)
+ROSTestStep::ROSTestStep(RunStepList *rsl)
+    : ROSGenericRunStep(rsl, Constants::ROS_TEST_ID)
 {
-  ctor();
+    ctor();
 }
 
-ROSTestStep::ROSTestStep(RunStepList *rsl, Utils::Id id) : ROSGenericRunStep(rsl, id)
+ROSTestStep::ROSTestStep(RunStepList *rsl, Utils::Id id)
+    : ROSGenericRunStep(rsl, id)
 {
-  ctor();
+    ctor();
 }
 
 void ROSTestStep::ctor()
 {
-  setCommand("rostest");
+    setCommand("rostest");
 }
 
 RunStepConfigWidget *ROSTestStep::createConfigWidget()
 {
-  return new ROSGenericRunStepConfigWidget(this, true, true, false);
+    return new ROSGenericRunStepConfigWidget(this, true, true, false);
 }
 
 QMap<QString, QString> ROSTestStep::getAvailableTargets()
 {
-  ROSBuildConfiguration *bc = qobject_cast<ROSBuildConfiguration *>(target()->activeBuildConfiguration());
-  return ROSUtils::getROSPackageExecutables(getPackage(), bc->environment().toStringList());
+    ROSBuildConfiguration *bc = qobject_cast<ROSBuildConfiguration *>(
+        target()->activeBuildConfiguration());
+    return ROSUtils::getROSPackageExecutables(getPackage(), bc->environment().toStringList());
 }
 
-ROSTestStepFactory::ROSTestStepFactory() :
-    RunStepFactory()
+ROSTestStepFactory::ROSTestStepFactory()
+    : RunStepFactory()
 {
-  registerStep<ROSTestStep>(Constants::ROS_TEST_ID);
-  setDisplayName("ROS Test Step");
-  setSupportedProjectType(Constants::ROS_PROJECT_ID);
-  setSupportedStepList(Constants::ROS_RUN_STEP_LIST_ID);
+    registerStep<ROSTestStep>(Constants::ROS_TEST_ID);
+    setDisplayName("ROS Test Step");
+    setSupportedProjectType(Constants::ROS_PROJECT_ID);
+    setSupportedStepList(Constants::ROS_RUN_STEP_LIST_ID);
 }
 
 } // namespace Internal

--- a/src/project_manager/ros_rostest_step.h
+++ b/src/project_manager/ros_rostest_step.h
@@ -26,25 +26,26 @@
 namespace ROSProjectManager {
 namespace Internal {
 
-namespace Ui { class ROSGenericStep; }
+namespace Ui {
+class ROSGenericStep;
+}
 
 class ROSTestStep : public ROSGenericRunStep
 {
-  Q_OBJECT
-  friend class ROSTestStepFactory;
+    Q_OBJECT
+    friend class ROSTestStepFactory;
 
 public:
-  ROSTestStep(RunStepList *rsl);
+    ROSTestStep(RunStepList *rsl);
 
 protected:
-  ROSTestStep(RunStepList *rsl, Utils::Id id);
+    ROSTestStep(RunStepList *rsl, Utils::Id id);
 
-  void ctor();
+    void ctor();
 
-  RunStepConfigWidget *createConfigWidget() override;
+    RunStepConfigWidget *createConfigWidget() override;
 
-  QMap<QString, QString> getAvailableTargets() override;
-
+    QMap<QString, QString> getAvailableTargets() override;
 };
 
 class ROSTestStepFactory : public RunStepFactory
@@ -53,6 +54,6 @@ public:
     ROSTestStepFactory();
 };
 
-} // Internal
-} // ROSProjectManager
+} // namespace Internal
+} // namespace ROSProjectManager
 #endif // ROS_ROSTEST_STEP_H

--- a/src/project_manager/ros_run_configuration.h
+++ b/src/project_manager/ros_run_configuration.h
@@ -21,28 +21,30 @@
 #ifndef ROS_RUN_CONFIGURATION_H
 #define ROS_RUN_CONFIGURATION_H
 
-#include "ros_run_step.h"
 #include "ros_project_constants.h"
-#include <projectexplorer/runconfiguration.h>
+#include "ros_run_step.h"
+#include <debugger/debuggerruncontrol.h>
 #include <projectexplorer/buildstep.h>
 #include <projectexplorer/devicesupport/deviceprocesslist.h>
-#include <debugger/debuggerruncontrol.h>
+#include <projectexplorer/runconfiguration.h>
 
-#include <QPointer>
-#include <QMenu>
 #include <QFutureInterface>
 #include <QFutureWatcher>
+#include <QMenu>
+#include <QPointer>
 #include <QTimer>
 
 QT_FORWARD_DECLARE_CLASS(QStringListModel)
-
 
 namespace ROSProjectManager {
 namespace Internal {
 
 class ROSRunConfigurationFactory;
 
-namespace Ui { class ROSRunConfiguration; class ROSLaunchConfiguration;}
+namespace Ui {
+class ROSRunConfiguration;
+class ROSLaunchConfiguration;
+} // namespace Ui
 
 class ROSRunConfiguration : public ProjectExplorer::RunConfiguration
 {
@@ -58,7 +60,6 @@ public:
     RunStepList *stepList() const;
 
 private:
-
     RunStepList *m_stepList;
 };
 
@@ -69,8 +70,8 @@ public:
     ~ROSRunConfigurationFactory() override;
 
 protected:
-    QList<ProjectExplorer::RunConfigurationCreationInfo>
-    availableCreators(ProjectExplorer::Target *parent) const override;
+    QList<ProjectExplorer::RunConfigurationCreationInfo> availableCreators(
+        ProjectExplorer::Target *parent) const override;
 };
 
 class ROSRunWorker : public ProjectExplorer::RunWorker

--- a/src/project_manager/ros_run_step.cpp
+++ b/src/project_manager/ros_run_step.cpp
@@ -30,8 +30,6 @@
 
 static const char runStepEnabledKey[] = "ProjectExplorer.RunStep.Enabled";
 
-
-
 namespace ROSProjectManager {
 namespace Internal {
 
@@ -163,11 +161,10 @@ RunStep *RunStepFactory::restore(RunStepList *parent, const QVariantMap &map)
 namespace {
 const char STEPS_COUNT_KEY[] = "ProjectExplorer.RunStepList.StepsCount";
 const char STEPS_PREFIX[] = "ProjectExplorer.RunStepList.Step.";
-}
+} // namespace
 
-
-RunStep::RunStep(RunStepList *rsl, Utils::Id id) :
-    ProjectConfiguration(rsl, id)
+RunStep::RunStep(RunStepList *rsl, Utils::Id id)
+    : ProjectConfiguration(rsl, id)
 {
     //
 }
@@ -189,7 +186,7 @@ ProjectExplorer::RunConfiguration *RunStep::runConfiguration() const
 {
     auto config = qobject_cast<ProjectExplorer::RunConfiguration *>(parent()->parent());
     if (config)
-      return config;
+        return config;
 
     return target()->activeRunConfiguration();
 }
@@ -249,13 +246,12 @@ bool RunStep::enabled() const
     return m_enabled;
 }
 
-RunStepList::RunStepList(QObject *parent, Utils::Id id) :
-    ProjectConfiguration(parent, id)
+RunStepList::RunStepList(QObject *parent, Utils::Id id)
+    : ProjectConfiguration(parent, id)
 {
     Q_ASSERT(parent);
     setDefaultDisplayName(tr("Run"));
 }
-
 
 RunStepList::~RunStepList()
 {
@@ -291,9 +287,7 @@ bool RunStepList::isEmpty() const
 
 bool RunStepList::contains(Utils::Id id) const
 {
-    return Utils::anyOf(steps(), [id](RunStep *rs){
-        return rs->id() == id;
-    });
+    return Utils::anyOf(steps(), [id](RunStep *rs) { return rs->id() == id; });
 }
 
 bool RunStepList::enabled() const
@@ -316,9 +310,11 @@ bool RunStepList::fromMap(const QVariantMap &map)
     const QList<RunStepFactory *> factories = RunStepFactory::allRunStepFactories();
     int maxSteps = map.value(QString::fromLatin1(STEPS_COUNT_KEY), 0).toInt();
     for (int i = 0; i < maxSteps; ++i) {
-        QVariantMap rsData(map.value(QString::fromLatin1(STEPS_PREFIX) + QString::number(i)).toMap());
+        QVariantMap rsData(
+            map.value(QString::fromLatin1(STEPS_PREFIX) + QString::number(i)).toMap());
         if (rsData.isEmpty()) {
-            Core::MessageManager::write(tr("[ROS Warning] No step data found for step %1 (continuing).").arg(i));
+            Core::MessageManager::write(
+                tr("[ROS Warning] No step data found for step %1 (continuing).").arg(i));
             continue;
         }
         bool handled = false;
@@ -330,7 +326,8 @@ bool RunStepList::fromMap(const QVariantMap &map)
                         appendStep(rs);
                         handled = true;
                     } else {
-                        Core::MessageManager::write(tr("[ROS Warning] Restoration of step %1 failed (continuing).").arg(i));
+                        Core::MessageManager::write(
+                            tr("[ROS Warning] Restoration of step %1 failed (continuing).").arg(i));
                     }
                 }
             }
@@ -342,12 +339,10 @@ bool RunStepList::fromMap(const QVariantMap &map)
 
 void RunStepList::runStep_enabledChanged(RunStep *step)
 {
-    if (step->enabled() == true)
-    {
-        for (RunStep *rs : m_steps)
-        {
-            if (rs->enabled() == true && rs->id() == Constants::ROS_ATTACH_TO_NODE_ID && rs != step)
-            {
+    if (step->enabled() == true) {
+        for (RunStep *rs : m_steps) {
+            if (rs->enabled() == true && rs->id() == Constants::ROS_ATTACH_TO_NODE_ID
+                && rs != step) {
                 rs->setEnabled(false);
             }
         }
@@ -359,27 +354,24 @@ QList<RunStep *> RunStepList::steps() const
     return m_steps;
 }
 
-QList<RunStep *> RunStepList::steps(const std::function<bool (const RunStep *)> &filter) const
+QList<RunStep *> RunStepList::steps(const std::function<bool(const RunStep *)> &filter) const
 {
     return Utils::filtered(steps(), filter);
 }
 
 void RunStepList::insertStep(int position, RunStep *step)
 {
-    if (step->id() == Constants::ROS_ATTACH_TO_NODE_ID)
-    {
-        if (step->enabled() == true)
-        {
-            for (RunStep *rs : m_steps)
-            {
-                if (rs->enabled() == true && rs->id() == Constants::ROS_ATTACH_TO_NODE_ID)
-                {
+    if (step->id() == Constants::ROS_ATTACH_TO_NODE_ID) {
+        if (step->enabled() == true) {
+            for (RunStep *rs : m_steps) {
+                if (rs->enabled() == true && rs->id() == Constants::ROS_ATTACH_TO_NODE_ID) {
                     rs->setEnabled(false);
                 }
             }
         }
-        connect(step, &RunStep::enabledChanged,
-                this, [this, step] () {runStep_enabledChanged(step);});
+        connect(step, &RunStep::enabledChanged, this, [this, step]() {
+            runStep_enabledChanged(step);
+        });
     }
     m_steps.insert(position, step);
     emit stepInserted(position);
@@ -410,9 +402,10 @@ RunStep *RunStepList::at(int position)
 ProjectExplorer::Target *RunStepList::target() const
 {
     Q_ASSERT(parent());
-    ProjectExplorer::RunConfiguration *rc = qobject_cast<ProjectExplorer::RunConfiguration *>(parent());
+    ProjectExplorer::RunConfiguration *rc = qobject_cast<ProjectExplorer::RunConfiguration *>(
+        parent());
     if (rc)
-      return rc->target();
+        return rc->target();
 
     return 0;
 }

--- a/src/project_manager/ros_run_step.h
+++ b/src/project_manager/ros_run_step.h
@@ -69,6 +69,7 @@ public:
 signals:
     void finished();
     void enabledChanged();
+
 private:
     bool m_enabled = true;
 };
@@ -78,8 +79,8 @@ class RunStepInfo
 public:
     enum Flags {
         Uncreatable = 1 << 0,
-        Unclonable  = 1 << 1,
-        UniqueStep  = 1 << 8    // Can't be used twice in a RunStepList
+        Unclonable = 1 << 1,
+        UniqueStep = 1 << 8 // Can't be used twice in a RunStepList
     };
 
     using RunStepCreator = std::function<RunStep *(RunStepList *)>;
@@ -109,7 +110,7 @@ protected:
     RunStepFactory(const RunStepFactory &) = delete;
     RunStepFactory &operator=(const RunStepFactory &) = delete;
 
-    template <class RunStepType>
+    template<class RunStepType>
     void registerStep(Utils::Id id)
     {
         QTC_CHECK(!m_info.creator);
@@ -149,24 +150,28 @@ public:
 
     QList<RunStep *> steps() const;
     QList<RunStep *> steps(const std::function<bool(const RunStep *)> &filter) const;
-        template <class RS> RS *firstOfType() {
-            RS *rs = nullptr;
-            for (int i = 0; i < count(); ++i) {
-                rs = qobject_cast<RS *>(at(i));
-                if (rs)
-                    return rs;
-            }
-            return nullptr;
+    template<class RS>
+    RS *firstOfType()
+    {
+        RS *rs = nullptr;
+        for (int i = 0; i < count(); ++i) {
+            rs = qobject_cast<RS *>(at(i));
+            if (rs)
+                return rs;
         }
-        template <class RS> QList<RS *>allOfType() {
-            QList<RS *> result;
-            RS *rs = nullptr;
-            for (int i = 0; i < count(); ++i) {
-                rs = qobject_cast<RS *>(at(i));
-                if (rs)
-                    result.append(rs);
-            }
-            return result;
+        return nullptr;
+    }
+    template<class RS>
+    QList<RS *> allOfType()
+    {
+        QList<RS *> result;
+        RS *rs = nullptr;
+        for (int i = 0; i < count(); ++i) {
+            rs = qobject_cast<RS *>(at(i));
+            if (rs)
+                result.append(rs);
+        }
+        return result;
     }
     int count() const;
     bool isEmpty() const;
@@ -216,7 +221,7 @@ private:
     bool m_showWidget = true;
 };
 
-} // Internal
-} // ROSProjectManager
+} // namespace Internal
+} // namespace ROSProjectManager
 
 #endif // RUNSTEP_H

--- a/src/project_manager/ros_run_steps_page.cpp
+++ b/src/project_manager/ros_run_steps_page.cpp
@@ -24,28 +24,29 @@
 #include <projectexplorer/projectexplorerconstants.h>
 #include <projectexplorer/projectexplorericons.h>
 
-#include <coreplugin/icore.h>
 #include <coreplugin/coreicons.h>
+#include <coreplugin/icore.h>
 #include <extensionsystem/pluginmanager.h>
-#include <utils/qtcassert.h>
 #include <utils/detailswidget.h>
 #include <utils/hostosinfo.h>
+#include <utils/qtcassert.h>
 #include <utils/theme/theme.h>
 
 #include <QSignalMapper>
 
-#include <QLabel>
-#include <QPushButton>
-#include <QMenu>
-#include <QVBoxLayout>
 #include <QHBoxLayout>
-#include <QToolButton>
+#include <QLabel>
+#include <QMenu>
 #include <QMessageBox>
+#include <QPushButton>
+#include <QToolButton>
+#include <QVBoxLayout>
 
 namespace ROSProjectManager {
 namespace Internal {
 
-ToolWidget::ToolWidget(QWidget *parent) : FadingPanel(parent)
+ToolWidget::ToolWidget(QWidget *parent)
+    : FadingPanel(parent)
 {
     auto layout = new QHBoxLayout;
     layout->setMargin(4);
@@ -89,7 +90,7 @@ ToolWidget::ToolWidget(QWidget *parent) : FadingPanel(parent)
     m_downButton->setIcon(ProjectExplorer::Icons::BUILDSTEP_MOVEDOWN.icon());
     hbox->addWidget(m_downButton);
 
-    m_removeButton  = new QToolButton(m_secondWidget);
+    m_removeButton = new QToolButton(m_secondWidget);
     m_removeButton->setAutoRaise(true);
     m_removeButton->setToolTip(RunStepListWidget::tr("Remove Item"));
     m_removeButton->setFixedSize(buttonSize);
@@ -162,8 +163,10 @@ void ToolWidget::setDownVisible(bool b)
     m_downButton->setVisible(b);
 }
 
-RunStepsWidgetData::RunStepsWidgetData(RunStep *s) :
-    step(s), widget(nullptr), detailsWidget(nullptr)
+RunStepsWidgetData::RunStepsWidgetData(RunStep *s)
+    : step(s)
+    , widget(nullptr)
+    , detailsWidget(nullptr)
 {
     widget = s->createConfigWidget();
     Q_ASSERT(widget);
@@ -186,10 +189,9 @@ RunStepsWidgetData::~RunStepsWidgetData()
     // We do not own the step
 }
 
-RunStepListWidget::RunStepListWidget(QWidget *parent) :
-    NamedWidget(tr("Steps"), parent)
-{
-}
+RunStepListWidget::RunStepListWidget(QWidget *parent)
+    : NamedWidget(tr("Steps"), parent)
+{}
 
 RunStepListWidget::~RunStepListWidget()
 {
@@ -246,12 +248,12 @@ void RunStepListWidget::init(RunStepList *rsl)
     setupUi();
 
     if (m_runStepList) {
-        disconnect(m_runStepList, &RunStepList::stepInserted,
-                   this, &RunStepListWidget::addRunStep);
-        disconnect(m_runStepList, &RunStepList::stepRemoved,
-                   this, &RunStepListWidget::removeRunStep);
-        disconnect(m_runStepList, &RunStepList::stepMoved,
-                   this, &RunStepListWidget::stepMoved);
+        disconnect(m_runStepList, &RunStepList::stepInserted, this, &RunStepListWidget::addRunStep);
+        disconnect(m_runStepList,
+                   &RunStepList::stepRemoved,
+                   this,
+                   &RunStepListWidget::removeRunStep);
+        disconnect(m_runStepList, &RunStepList::stepMoved, this, &RunStepListWidget::stepMoved);
     }
 
     connect(rsl, &RunStepList::stepInserted, this, &RunStepListWidget::addRunStep);
@@ -280,38 +282,38 @@ void RunStepListWidget::init(RunStepList *rsl)
 
 void RunStepListWidget::updateAddRunStepMenu()
 {
-  QMap<QString, QPair<Utils::Id, RunStepFactory *> > map;
-  //Build up a list of possible steps and save map the display names to the (internal) name and factories.
-  for (RunStepFactory *factory : RunStepFactory::allRunStepFactories()) {
-      if (factory->canHandle(m_runStepList)) {
-          const RunStepInfo &info = factory->stepInfo();
-          if (info.flags & RunStepInfo::Uncreatable)
-              continue;
-          if ((info.flags & RunStepInfo::UniqueStep) && m_runStepList->contains(info.id))
-              continue;
-          map.insert(info.displayName, qMakePair(info.id, factory));
-      }
-  }
+    QMap<QString, QPair<Utils::Id, RunStepFactory *>> map;
+    //Build up a list of possible steps and save map the display names to the (internal) name and factories.
+    for (RunStepFactory *factory : RunStepFactory::allRunStepFactories()) {
+        if (factory->canHandle(m_runStepList)) {
+            const RunStepInfo &info = factory->stepInfo();
+            if (info.flags & RunStepInfo::Uncreatable)
+                continue;
+            if ((info.flags & RunStepInfo::UniqueStep) && m_runStepList->contains(info.id))
+                continue;
+            map.insert(info.displayName, qMakePair(info.id, factory));
+        }
+    }
 
-  // Ask the user which one to add
-  QMenu *menu = m_addButton->menu();
-  menu->clear();
-  if (!map.isEmpty()) {
-      QMap<QString, QPair<Utils::Id, RunStepFactory *> >::const_iterator it, end;
-      end = map.constEnd();
-      for (it = map.constBegin(); it != end; ++it) {
-          QAction *action = menu->addAction(it.key());
-          RunStepFactory *factory = it.value().second;
-          Utils::Id id = it.value().first;
+    // Ask the user which one to add
+    QMenu *menu = m_addButton->menu();
+    menu->clear();
+    if (!map.isEmpty()) {
+        QMap<QString, QPair<Utils::Id, RunStepFactory *>>::const_iterator it, end;
+        end = map.constEnd();
+        for (it = map.constBegin(); it != end; ++it) {
+            QAction *action = menu->addAction(it.key());
+            RunStepFactory *factory = it.value().second;
+            Utils::Id id = it.value().first;
 
-          connect(action, &QAction::triggered, [id, factory, this]() {
-              RunStep *newStep = factory->create(m_runStepList, id);
-              QTC_ASSERT(newStep, return);
-              int pos = m_runStepList->count();
-              m_runStepList->insertStep(pos, newStep);
-          });
-      }
-  }
+            connect(action, &QAction::triggered, [id, factory, this]() {
+                RunStep *newStep = factory->create(m_runStepList, id);
+                QTC_ASSERT(newStep, return );
+                int pos = m_runStepList->count();
+                m_runStepList->insertStep(pos, newStep);
+            });
+        }
+    }
 }
 
 void RunStepListWidget::addRunStepWidget(int pos, RunStep *step)
@@ -322,13 +324,13 @@ void RunStepListWidget::addRunStepWidget(int pos, RunStep *step)
 
     m_vbox->insertWidget(pos, s->detailsWidget);
 
-    connect(s->widget, &RunStepConfigWidget::updateSummary,
-            this, &RunStepListWidget::updateSummary);
-    connect(s->widget, &RunStepConfigWidget::updateAdditionalSummary,
-            this, &RunStepListWidget::updateAdditionalSummary);
+    connect(s->widget, &RunStepConfigWidget::updateSummary, this, &RunStepListWidget::updateSummary);
+    connect(s->widget,
+            &RunStepConfigWidget::updateAdditionalSummary,
+            this,
+            &RunStepListWidget::updateAdditionalSummary);
 
-    connect(s->step, &RunStep::enabledChanged,
-            this, &RunStepListWidget::updateEnabledState);
+    connect(s->step, &RunStep::enabledChanged, this, &RunStepListWidget::updateEnabledState);
 }
 
 void RunStepListWidget::addRunStep(int pos)
@@ -393,8 +395,10 @@ void RunStepListWidget::setupUi()
 
     m_vbox->addLayout(hboxLayout);
 
-    connect(m_addButton->menu(), &QMenu::aboutToShow,
-            this, &RunStepListWidget::updateAddRunStepMenu);
+    connect(m_addButton->menu(),
+            &QMenu::aboutToShow,
+            this,
+            &RunStepListWidget::updateAddRunStepMenu);
 }
 
 void RunStepListWidget::updateRunStepButtonsState()
@@ -404,33 +408,34 @@ void RunStepListWidget::updateRunStepButtonsState()
     for (int i = 0; i < m_runStepsData.count(); ++i) {
         RunStepsWidgetData *s = m_runStepsData.at(i);
         disconnect(s->toolWidget, nullptr, this, nullptr);
-        connect(s->toolWidget, &ToolWidget::disabledClicked,
-                this, [s] {
+        connect(s->toolWidget, &ToolWidget::disabledClicked, this, [s] {
             RunStep *rs = s->step;
             rs->setEnabled(!rs->enabled());
             s->toolWidget->setRunStepEnabled(rs->enabled());
         });
         s->toolWidget->setRemoveEnabled(!m_runStepList->at(i)->immutable());
-        connect(s->toolWidget, &ToolWidget::removeClicked,
-                this, [this, i] {
+        connect(s->toolWidget, &ToolWidget::removeClicked, this, [this, i] {
             if (!m_runStepList->removeStep(i)) {
                 QMessageBox::warning(Core::ICore::mainWindow(),
                                      tr("Removing Step failed"),
                                      tr("Cannot remove run step"),
-                                     QMessageBox::Ok, QMessageBox::Ok);
+                                     QMessageBox::Ok,
+                                     QMessageBox::Ok);
             }
         });
 
-        s->toolWidget->setUpEnabled((i > 0)
-                                    && !(m_runStepList->at(i)->immutable()
-                                         && m_runStepList->at(i - 1)->immutable()));
-        connect(s->toolWidget, &ToolWidget::upClicked,
-                this, [this, i] { m_runStepList->moveStepUp(i); });
-        s->toolWidget->setDownEnabled((i + 1 < m_runStepList->count())
-                                      && !(m_runStepList->at(i)->immutable()
-                                           && m_runStepList->at(i + 1)->immutable()));
-        connect(s->toolWidget, &ToolWidget::downClicked,
-                this, [this, i] { m_runStepList->moveStepUp(i + 1); });
+        s->toolWidget->setUpEnabled(
+            (i > 0)
+            && !(m_runStepList->at(i)->immutable() && m_runStepList->at(i - 1)->immutable()));
+        connect(s->toolWidget, &ToolWidget::upClicked, this, [this, i] {
+            m_runStepList->moveStepUp(i);
+        });
+        s->toolWidget->setDownEnabled(
+            (i + 1 < m_runStepList->count())
+            && !(m_runStepList->at(i)->immutable() && m_runStepList->at(i + 1)->immutable()));
+        connect(s->toolWidget, &ToolWidget::downClicked, this, [this, i] {
+            m_runStepList->moveStepUp(i + 1);
+        });
 
         // Only show buttons when needed
         s->toolWidget->setDownVisible(m_runStepList->count() != 1);
@@ -438,10 +443,10 @@ void RunStepListWidget::updateRunStepButtonsState()
     }
 }
 
-RunStepsPage::RunStepsPage(ROSRunConfiguration *rc, Utils::Id id) :
-    NamedWidget(tr("ROS Run Steps")),
-    m_id(id),
-    m_widget(new RunStepListWidget(this))
+RunStepsPage::RunStepsPage(ROSRunConfiguration *rc, Utils::Id id)
+    : NamedWidget(tr("ROS Run Steps"))
+    , m_id(id)
+    , m_widget(new RunStepListWidget(this))
 {
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setMargin(0);

--- a/src/project_manager/ros_run_steps_page.h
+++ b/src/project_manager/ros_run_steps_page.h
@@ -21,8 +21,8 @@
 #ifndef ROSRUNSTEPSPAGE_H
 #define ROSRUNSTEPSPAGE_H
 
-#include "ros_run_step.h"
 #include "ros_run_configuration.h"
+#include "ros_run_step.h"
 
 #include <projectexplorer/buildstep.h>
 #include <projectexplorer/namedwidget.h>
@@ -37,9 +37,13 @@ class QSignalMapper;
 class QGraphicsOpacityEffect;
 QT_END_NAMESPACE
 
-namespace Utils { class DetailsWidget; }
+namespace Utils {
+class DetailsWidget;
+}
 
-namespace ProjectExplorer { class Target; }
+namespace ProjectExplorer {
+class Target;
+}
 
 namespace ROSProjectManager {
 namespace Internal {
@@ -123,7 +127,9 @@ private:
     QPushButton *m_addButton = nullptr;
 };
 
-namespace Ui { class RunStepsPage; }
+namespace Ui {
+class RunStepsPage;
+}
 
 class RunStepsPage : public ProjectExplorer::NamedWidget
 {
@@ -137,7 +143,7 @@ private:
     RunStepListWidget *m_widget = nullptr;
 };
 
-} // Internal
-} // ROSProjectManager
+} // namespace Internal
+} // namespace ROSProjectManager
 
 #endif // ROSRUNSTEPSPAGE_H

--- a/src/project_manager/ros_settings_page.cpp
+++ b/src/project_manager/ros_settings_page.cpp
@@ -21,15 +21,14 @@
 #include "ros_settings_page.h"
 #include "ros_project_constants.h"
 #include "ui_ros_settings_page.h"
-#include "ros_project_constants.h"
 #include <QDir>
 
 #include <coreplugin/icore.h>
 
+#include <texteditor/codestylepool.h>
 #include <texteditor/icodestylepreferences.h>
 #include <texteditor/icodestylepreferencesfactory.h>
 #include <texteditor/texteditorsettings.h>
-#include <texteditor/codestylepool.h>
 
 #include <cpptools/cpptoolsconstants.h>
 
@@ -38,27 +37,28 @@
 static const char DEFAULT_DISTRIBUTION_ID[] = "ROSProjectManager.ROSSettingsDefaultDistribution";
 static const char DEFAULT_BUILD_SYSTEM_ID[] = "ROSProjectManager.ROSSettingsDefaultBuildSystem";
 static const char DEFAULT_CODE_STYLE_ID[] = "ROSProjectManager.ROSSettingsDefaultCodeStyle";
-static const char DEFAULT_DISTRIBUTION_PATH_ID[] = "ROSProjectManager.ROSSettingsDefaultDistributionPath";
-static const char CUSTOM_DISTRIBUTION_PATH_ID[] = "ROSProjectManager.ROSSettingsCustomDistributionPath";
+static const char DEFAULT_DISTRIBUTION_PATH_ID[]
+    = "ROSProjectManager.ROSSettingsDefaultDistributionPath";
+static const char CUSTOM_DISTRIBUTION_PATH_ID[]
+    = "ROSProjectManager.ROSSettingsCustomDistributionPath";
 
 namespace ROSProjectManager {
 namespace Internal {
 
 ROSSettings::ROSSettings()
 {
-  m_system_distributions.clear();
-  Utils::FilePath ros_path = Utils::FilePath::fromString(Constants::ROS_INSTALL_DIRECTORY);
-  if (ros_path.exists())
-  {
-    QDir ros_opt(ros_path.toString());
-    ros_opt.setFilter(QDir::NoDotAndDotDot | QDir::Dirs);
-    for (auto entry : ros_opt.entryList())
-    {
-      Utils::FilePath path = Utils::FilePath::fromString(QLatin1String(ROSProjectManager::Constants::ROS_INSTALL_DIRECTORY));
-      path = path.pathAppended(entry);
-      m_system_distributions.append(path);
+    m_system_distributions.clear();
+    Utils::FilePath ros_path = Utils::FilePath::fromString(Constants::ROS_INSTALL_DIRECTORY);
+    if (ros_path.exists()) {
+        QDir ros_opt(ros_path.toString());
+        ros_opt.setFilter(QDir::NoDotAndDotDot | QDir::Dirs);
+        for (auto entry : ros_opt.entryList()) {
+            Utils::FilePath path = Utils::FilePath::fromString(
+                QLatin1String(ROSProjectManager::Constants::ROS_INSTALL_DIRECTORY));
+            path = path.pathAppended(entry);
+            m_system_distributions.append(path);
+        }
     }
-  }
 }
 
 void ROSSettings::toSettings(QSettings *s) const
@@ -69,9 +69,9 @@ void ROSSettings::toSettings(QSettings *s) const
     s->setValue(DEFAULT_CODE_STYLE_ID, default_code_style);
 
     if (default_dist_path.isEmpty())
-      s->setValue(DEFAULT_DISTRIBUTION_PATH_ID, Constants::ROS_INSTALL_DIRECTORY);
+        s->setValue(DEFAULT_DISTRIBUTION_PATH_ID, Constants::ROS_INSTALL_DIRECTORY);
     else
-      s->setValue(DEFAULT_DISTRIBUTION_PATH_ID, default_dist_path);
+        s->setValue(DEFAULT_DISTRIBUTION_PATH_ID, default_dist_path);
 
     s->setValue(CUSTOM_DISTRIBUTION_PATH_ID, custom_dist_path);
 
@@ -85,14 +85,17 @@ void ROSSettings::fromSettings(QSettings *s)
     default_distribution = s->value(DEFAULT_DISTRIBUTION_ID, "").toString();
 
     if (default_distribution.isEmpty() && !m_system_distributions.empty())
-      default_distribution = m_system_distributions.first().toString();
+        default_distribution = m_system_distributions.first().toString();
 
-    default_build_system = static_cast<ROSUtils::BuildSystem>(s->value(DEFAULT_BUILD_SYSTEM_ID, static_cast<int>(ROSUtils::BuildSystem::CatkinTools)).toInt());
+    default_build_system = static_cast<ROSUtils::BuildSystem>(
+        s->value(DEFAULT_BUILD_SYSTEM_ID, static_cast<int>(ROSUtils::BuildSystem::CatkinTools))
+            .toInt());
     default_code_style = s->value(DEFAULT_CODE_STYLE_ID, "ROS").toString();
-    default_dist_path = s->value(DEFAULT_DISTRIBUTION_PATH_ID, Constants::ROS_INSTALL_DIRECTORY).toString();
+    default_dist_path = s->value(DEFAULT_DISTRIBUTION_PATH_ID, Constants::ROS_INSTALL_DIRECTORY)
+                            .toString();
 
     if (default_dist_path.isEmpty())
-      default_dist_path = Constants::ROS_INSTALL_DIRECTORY;
+        default_dist_path = Constants::ROS_INSTALL_DIRECTORY;
 
     custom_dist_path = s->value(CUSTOM_DISTRIBUTION_PATH_ID, "").toString();
     s->endGroup();
@@ -109,33 +112,34 @@ bool ROSSettings::equals(const ROSSettings &rhs) const
 
 // ------------------ ROSSettingsWidget
 
-ROSSettingsWidget::ROSSettingsWidget(QWidget *parent) :
-    QWidget(parent),
-    m_ui(new Ui::ROSSettingsPage),
-    m_available_code_style_names(new QStringListModel)
+ROSSettingsWidget::ROSSettingsWidget(QWidget *parent)
+    : QWidget(parent)
+    , m_ui(new Ui::ROSSettingsPage)
+    , m_available_code_style_names(new QStringListModel)
 {
     m_ui->setupUi(this);
 
     // Add available ros distributions
     QStringList installed_distributions;
-    for(auto entry : ROSUtils::installedDistributions())
-      installed_distributions.append(entry.toString());
+    for (auto entry : ROSUtils::installedDistributions())
+        installed_distributions.append(entry.toString());
 
     m_ui->distributionComboBox->addItems(installed_distributions);
 
     if (!installed_distributions.empty())
-      m_ui->distributionComboBox->setCurrentIndex(0);
+        m_ui->distributionComboBox->setCurrentIndex(0);
 
     // See ProjectExplorer::CodeStyleSettingsWidget and ProjectExplorer::EditorConfiguration as an example
     // TODO: Add python support
-    TextEditor::CodeStylePool *code_style_pool = TextEditor::TextEditorSettings::codeStylePool(CppTools::Constants::CPP_SETTINGS_ID);
+    TextEditor::CodeStylePool *code_style_pool = TextEditor::TextEditorSettings::codeStylePool(
+        CppTools::Constants::CPP_SETTINGS_ID);
 
-    for (const auto& code_style : code_style_pool->builtInCodeStyles()) {
+    for (const auto &code_style : code_style_pool->builtInCodeStyles()) {
         QString name = code_style->displayName() + " [built-in]";
         m_available_code_styles[name] = code_style->displayName();
     }
 
-    for (const auto& code_style : code_style_pool->customCodeStyles()) {
+    for (const auto &code_style : code_style_pool->customCodeStyles()) {
         QString name = code_style->displayName();
         if (name != "Global")
             m_available_code_styles[name] = name;
@@ -155,12 +159,13 @@ ROSSettings ROSSettingsWidget::settings() const
 {
     ROSSettings rc;
     rc.default_distribution = m_ui->distributionComboBox->currentText();
-    rc.default_build_system = static_cast<ROSUtils::BuildSystem>(m_ui->buildSystemComboBox->currentIndex());
+    rc.default_build_system = static_cast<ROSUtils::BuildSystem>(
+        m_ui->buildSystemComboBox->currentIndex());
     rc.default_code_style = m_available_code_styles[m_ui->codeStyleComboBox->currentText()];
     rc.default_dist_path = m_ui->defaultDistributionPathChooser->path();
 
     if (rc.default_dist_path.isEmpty())
-      rc.default_dist_path = Constants::ROS_INSTALL_DIRECTORY;
+        rc.default_dist_path = Constants::ROS_INSTALL_DIRECTORY;
 
     rc.custom_dist_path = m_ui->customDistributionPathChooser->path();
     return rc;
@@ -173,7 +178,7 @@ void ROSSettingsWidget::setSettings(const ROSSettings &s)
 
     m_ui->buildSystemComboBox->setCurrentIndex(static_cast<int>(s.default_build_system));
 
-    for (const auto& key : m_available_code_styles.keys()) {
+    for (const auto &key : m_available_code_styles.keys()) {
         if (m_available_code_styles.value(key) == s.default_code_style) {
             idx = m_ui->codeStyleComboBox->findText(key, Qt::MatchExactly);
             m_ui->codeStyleComboBox->setCurrentIndex(idx);
@@ -182,29 +187,29 @@ void ROSSettingsWidget::setSettings(const ROSSettings &s)
     }
 
     if (s.default_dist_path.isEmpty())
-      m_ui->defaultDistributionPathChooser->setPath(Constants::ROS_INSTALL_DIRECTORY);
+        m_ui->defaultDistributionPathChooser->setPath(Constants::ROS_INSTALL_DIRECTORY);
     else
-      m_ui->defaultDistributionPathChooser->setPath(s.default_dist_path);
+        m_ui->defaultDistributionPathChooser->setPath(s.default_dist_path);
 
     m_ui->customDistributionPathChooser->setPath(s.custom_dist_path);
 }
 
 // --------------- ROSSettingsPage
-ROSSettingsPage::ROSSettingsPage(QSharedPointer<ROSSettings> &settings,
-                                 QObject *parent) :
-    Core::IOptionsPage(parent),
-    m_settings(settings)
+ROSSettingsPage::ROSSettingsPage(QSharedPointer<ROSSettings> &settings, QObject *parent)
+    : Core::IOptionsPage(parent)
+    , m_settings(settings)
 {
     setId(Constants::ROS_SETTINGS_MAIN_PAGE_ID);
-    setDisplayName(QCoreApplication::translate(Constants::ROS_SETTINGS_MAIN_PAGE_NAME_ID, "ROS Main Settings"));
+    setDisplayName(QCoreApplication::translate(Constants::ROS_SETTINGS_MAIN_PAGE_NAME_ID,
+                                               "ROS Main Settings"));
     setCategory(Constants::ROS_SETTINGS_CATEGORY_ID);
     setDisplayCategory(QCoreApplication::translate(Constants::ROS_SETTINGS_CATEGORY_NAME_ID, "ROS"));
-    setCategoryIcon(Utils::Icon({{":rosproject/ros_icon.png", Utils::Theme::PanelTextColorDark}}, Utils::Icon::Tint));
+    setCategoryIcon(Utils::Icon({{":rosproject/ros_icon.png", Utils::Theme::PanelTextColorDark}},
+                                Utils::Icon::Tint));
 }
 
 QWidget *ROSSettingsPage::widget()
 {
-
     if (!m_widget) {
         m_widget = new ROSSettingsWidget;
         m_widget->setSettings(*m_settings);

--- a/src/project_manager/ros_settings_page.h
+++ b/src/project_manager/ros_settings_page.h
@@ -25,9 +25,9 @@
 
 #include <coreplugin/dialogs/ioptionspage.h>
 
-#include <QWidget>
 #include <QPointer>
 #include <QStringListModel>
+#include <QWidget>
 
 namespace ROSProjectManager {
 namespace Internal {
@@ -63,26 +63,25 @@ private:
 
 class ROSSettingsWidget : public QWidget
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  explicit ROSSettingsWidget(QWidget *parent = 0);
-  ~ROSSettingsWidget();
+    explicit ROSSettingsWidget(QWidget *parent = 0);
+    ~ROSSettingsWidget();
 
-  ROSSettings settings() const;
-  void setSettings(const ROSSettings &settings);
+    ROSSettings settings() const;
+    void setSettings(const ROSSettings &settings);
 
 private:
-  Ui::ROSSettingsPage *m_ui;
-  QStringListModel *m_available_code_style_names;
-  QMap<QString, QString> m_available_code_styles;
+    Ui::ROSSettingsPage *m_ui;
+    QStringListModel *m_available_code_style_names;
+    QMap<QString, QString> m_available_code_styles;
 };
 
 class ROSSettingsPage : public Core::IOptionsPage
 {
 public:
-    explicit ROSSettingsPage(QSharedPointer<ROSSettings> &settings,
-                             QObject *parent = nullptr);
+    explicit ROSSettingsPage(QSharedPointer<ROSSettings> &settings, QObject *parent = nullptr);
 
     QWidget *widget();
     void apply();

--- a/src/project_manager/ros_terminal_pane.h
+++ b/src/project_manager/ros_terminal_pane.h
@@ -26,65 +26,64 @@
 #include <projectexplorer/processparameters.h>
 #include <utils/qtcprocess.h>
 
+#include <QProcess>
 #include <QTabWidget>
 #include <QToolButton>
-#include <QProcess>
 
 #include <qtermwidget5/qtermwidget.h>
 
 namespace ROSProjectManager {
 namespace Internal {
 
-
 class ROSTerminalPane : public Core::IOutputPane
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  ROSTerminalPane();
-  ~ROSTerminalPane();
+    ROSTerminalPane();
+    ~ROSTerminalPane();
 
-  QWidget *outputWidget(QWidget *parent) override;
-  QList<QWidget *> toolBarWidgets() const override;
-  QString displayName() const override;
+    QWidget *outputWidget(QWidget *parent) override;
+    QList<QWidget *> toolBarWidgets() const override;
+    QString displayName() const override;
 
-  int priorityInStatusBar() const override;
+    int priorityInStatusBar() const override;
 
-  void clearContents() override;
-  void visibilityChanged(bool visible) override;
+    void clearContents() override;
+    void visibilityChanged(bool visible) override;
 
-  void setFocus() override;
-  bool hasFocus() const override;
-  bool canFocus() const override;
+    void setFocus() override;
+    bool hasFocus() const override;
+    bool canFocus() const override;
 
-  bool canNavigate() const override;
-  bool canNext() const override;
-  bool canPrevious() const override;
-  void goToNext() override;
-  void goToPrev() override;
+    bool canNavigate() const override;
+    bool canNext() const override;
+    bool canPrevious() const override;
+    void goToNext() override;
+    void goToPrev() override;
 
-  QTermWidget &startTerminal(int startnow = 1, const QString name = QLatin1String("Terminal"));
+    QTermWidget &startTerminal(int startnow = 1, const QString name = QLatin1String("Terminal"));
 
-  void sendText(const QString &text);
+    void sendText(const QString &text);
 
 private slots:
-  void updateToolBarButtonsEnabled();
-  void zoomIn();
-  void zoomOut();
-  void startTerminalButton();
-  void stopProcess();
-  void closeTerminal(int index);
-  void termKeyPressed(QKeyEvent *event);
+    void updateToolBarButtonsEnabled();
+    void zoomIn();
+    void zoomOut();
+    void startTerminalButton();
+    void stopProcess();
+    void closeTerminal(int index);
+    void termKeyPressed(QKeyEvent *event);
 
 private:
-  QList<QTermWidget *> m_terminals;
-  QTabWidget * m_tabWidget;
-  QStringList m_tabNames;
+    QList<QTermWidget *> m_terminals;
+    QTabWidget *m_tabWidget;
+    QStringList m_tabNames;
 
-  QToolButton *m_stopButton;
-  QToolButton *m_zoomInButton;
-  QToolButton *m_zoomOutButton;
-  QToolButton *m_newTerminalButton;
+    QToolButton *m_stopButton;
+    QToolButton *m_zoomInButton;
+    QToolButton *m_zoomOutButton;
+    QToolButton *m_newTerminalButton;
 };
 
 } // namespace Internal

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -19,29 +19,26 @@
  * limitations under the License.
  */
 #include "ros_utils.h"
-#include "ros_project_constants.h"
 #include "ros_packagexml_parser.h"
-#include "ros_settings_page.h"
+#include "ros_project_constants.h"
 #include "ros_project_plugin.h"
+#include "ros_settings_page.h"
 
-#include <utils/fileutils.h>
 #include <coreplugin/messagemanager.h>
-#include <yaml-cpp/yaml.h>
 #include <fstream>
-#include <QDir>
+#include <utils/fileutils.h>
+#include <yaml-cpp/yaml.h>
 #include <QDebug>
-#include <QFile>
-#include <QTextStream>
+#include <QDir>
 #include <QDirIterator>
+#include <QFile>
 #include <QStandardPaths>
+#include <QTextStream>
 
 namespace ROSProjectManager {
 namespace Internal {
 
-ROSUtils::ROSUtils()
-{
-
-}
+ROSUtils::ROSUtils() {}
 
 QString ROSUtils::buildTypeName(const ROSUtils::BuildType &buildType)
 {
@@ -61,11 +58,16 @@ QString ROSUtils::buildTypeName(const ROSUtils::BuildType &buildType)
 
 bool ROSUtils::sourceROS(QProcess *process, const Utils::FilePath &rosDistribution)
 {
-  bool results = sourceWorkspaceHelper(process, Utils::FilePath(rosDistribution).pathAppended(QLatin1String("setup.bash")).toString());
-  if (!results)
-    Core::MessageManager::write(QObject::tr("[ROS Warning] Faild to source ROS Distribution: %1.").arg(rosDistribution.toString()));
+    bool results = sourceWorkspaceHelper(process,
+                                         Utils::FilePath(rosDistribution)
+                                             .pathAppended(QLatin1String("setup.bash"))
+                                             .toString());
+    if (!results)
+        Core::MessageManager::write(
+            QObject::tr("[ROS Warning] Faild to source ROS Distribution: %1.")
+                .arg(rosDistribution.toString()));
 
-  return results;
+    return results;
 }
 
 bool ROSUtils::sourceWorkspace(QProcess *process, const WorkspaceInfo &workspaceInfo)
@@ -75,53 +77,52 @@ bool ROSUtils::sourceWorkspace(QProcess *process, const WorkspaceInfo &workspace
 
     Utils::FilePath bash(workspaceInfo.develPath);
     if (workspaceInfo.install)
-      bash = Utils::FilePath(workspaceInfo.installPath);
+        bash = Utils::FilePath(workspaceInfo.installPath);
 
     bash = bash.pathAppended(QLatin1String("setup.bash"));
-    if (bash.exists())
-    {
-        Core::MessageManager::write(QObject::tr("[ROS Debug] Sourced workspace: %1.").arg(bash.toString()));
+    if (bash.exists()) {
+        Core::MessageManager::write(
+            QObject::tr("[ROS Debug] Sourced workspace: %1.").arg(bash.toString()));
         if (sourceWorkspaceHelper(process, bash.toString()))
             return true;
-    }
-    else
-    {
-        Core::MessageManager::write(QObject::tr("[ROS Warning] Failed to source workspace because this file does not exist: %1.").arg(bash.toString()));
+    } else {
+        Core::MessageManager::write(
+            QObject::tr(
+                "[ROS Warning] Failed to source workspace because this file does not exist: %1.")
+                .arg(bash.toString()));
         return true;
     }
 
-    Core::MessageManager::write(QObject::tr("[ROS Warning] Failed to source workspace: %1.").arg(workspaceInfo.path.toString()));
+    Core::MessageManager::write(QObject::tr("[ROS Warning] Failed to source workspace: %1.")
+                                    .arg(workspaceInfo.path.toString()));
     return false;
 }
 
 bool ROSUtils::isWorkspaceInitialized(const WorkspaceInfo &workspaceInfo)
 {
     switch (workspaceInfo.buildSystem) {
-    case ROSUtils::CatkinMake:
-    {
+    case ROSUtils::CatkinMake: {
         Utils::FilePath topCMake(workspaceInfo.sourcePath);
         topCMake = topCMake.pathAppended(QLatin1String("CMakeLists.txt"));
         Utils::FilePath catkin_workspace(workspaceInfo.path);
         catkin_workspace = catkin_workspace.pathAppended(QLatin1String(".catkin_workspace"));
 
         if (topCMake.exists() && catkin_workspace.exists() && workspaceInfo.sourcePath.exists())
-          return true;
+            return true;
 
         return false;
     }
-    case ROSUtils::CatkinTools:
-    {
+    case ROSUtils::CatkinTools: {
         Utils::FilePath catkin_tools(workspaceInfo.path);
         catkin_tools = catkin_tools.pathAppended(QLatin1String(".catkin_tools"));
         if (catkin_tools.exists() && workspaceInfo.sourcePath.exists())
-          return true;
+            return true;
 
         return false;
     }
-    case ROSUtils::Colcon:
-    {
+    case ROSUtils::Colcon: {
         if (workspaceInfo.sourcePath.exists())
-          return true;
+            return true;
 
         return false;
     }
@@ -133,32 +134,42 @@ bool ROSUtils::isWorkspaceInitialized(const WorkspaceInfo &workspaceInfo)
 bool ROSUtils::initializeWorkspaceFolders(const WorkspaceInfo &workspaceInfo)
 {
     if (!workspaceInfo.sourcePath.exists())
-        if( ! QDir().mkpath(workspaceInfo.sourcePath.toString()) ) {
-            Core::MessageManager::write(QObject::tr("[ROS Warning] Failed to initialize workspace folder: %1.").arg(workspaceInfo.sourcePath.toString()));
+        if (!QDir().mkpath(workspaceInfo.sourcePath.toString())) {
+            Core::MessageManager::write(
+                QObject::tr("[ROS Warning] Failed to initialize workspace folder: %1.")
+                    .arg(workspaceInfo.sourcePath.toString()));
             return false;
         }
 
     if (!workspaceInfo.logPath.exists())
-        if( ! QDir().mkpath(workspaceInfo.logPath.toString()) ) {
-            Core::MessageManager::write(QObject::tr("[ROS Warning] Failed to initialize workspace folder: %1.").arg(workspaceInfo.logPath.toString()));
+        if (!QDir().mkpath(workspaceInfo.logPath.toString())) {
+            Core::MessageManager::write(
+                QObject::tr("[ROS Warning] Failed to initialize workspace folder: %1.")
+                    .arg(workspaceInfo.logPath.toString()));
             return false;
         }
 
     if (!workspaceInfo.buildPath.exists())
-        if( ! QDir().mkpath(workspaceInfo.buildPath.toString()) ) {
-            Core::MessageManager::write(QObject::tr("[ROS Warning] Failed to initialize workspace folder: %1.").arg(workspaceInfo.buildPath.toString()));
+        if (!QDir().mkpath(workspaceInfo.buildPath.toString())) {
+            Core::MessageManager::write(
+                QObject::tr("[ROS Warning] Failed to initialize workspace folder: %1.")
+                    .arg(workspaceInfo.buildPath.toString()));
             return false;
         }
 
     if (!workspaceInfo.develPath.exists())
-        if( ! QDir().mkpath(workspaceInfo.develPath.toString()) ) {
-            Core::MessageManager::write(QObject::tr("[ROS Warning] Failed to initialize workspace folder: %1.").arg(workspaceInfo.develPath.toString()));
+        if (!QDir().mkpath(workspaceInfo.develPath.toString())) {
+            Core::MessageManager::write(
+                QObject::tr("[ROS Warning] Failed to initialize workspace folder: %1.")
+                    .arg(workspaceInfo.develPath.toString()));
             return false;
         }
 
     if (!workspaceInfo.installPath.exists())
-        if( ! QDir().mkpath(workspaceInfo.installPath.toString()) ) {
-            Core::MessageManager::write(QObject::tr("[ROS Warning] Failed to initialize workspace folder: %1.").arg(workspaceInfo.installPath.toString()));
+        if (!QDir().mkpath(workspaceInfo.installPath.toString())) {
+            Core::MessageManager::write(
+                QObject::tr("[ROS Warning] Failed to initialize workspace folder: %1.")
+                    .arg(workspaceInfo.installPath.toString()));
             return false;
         }
 
@@ -170,85 +181,95 @@ bool ROSUtils::initializeWorkspace(QProcess *process, const WorkspaceInfo &works
     WorkspaceInfo workspace = workspaceInfo;
 
     if (sourceROS(process, workspaceInfo.rosDistribution))
-        if (!isWorkspaceInitialized(workspaceInfo))
-        {
+        if (!isWorkspaceInitialized(workspaceInfo)) {
             switch (workspaceInfo.buildSystem) {
-            case CatkinMake:
-            {
-                if( !initializeWorkspaceFolders(workspaceInfo) )
+            case CatkinMake: {
+                if (!initializeWorkspaceFolders(workspaceInfo))
                     return false;
 
                 process->setWorkingDirectory(workspaceInfo.sourcePath.toString());
-                process->start(QLatin1String("bash"), QStringList() << QStringList() << QLatin1String("-c") << QLatin1String("catkin_init_workspace"));
+                process->start(QLatin1String("bash"),
+                               QStringList() << QStringList() << QLatin1String("-c")
+                                             << QLatin1String("catkin_init_workspace"));
 
-                if( !process->waitForFinished() )
+                if (!process->waitForFinished())
                     return false;
 
                 break;
             }
-            case CatkinTools:
-            {
+            case CatkinTools: {
                 setCatkinToolsDefaultProfile(workspace.path);
 
                 workspace = ROSUtils::getWorkspaceInfo(workspace.path,
                                                        workspace.buildSystem,
                                                        workspace.rosDistribution);
 
-                if( !initializeWorkspaceFolders(workspace) )
+                if (!initializeWorkspaceFolders(workspace))
                     return false;
 
                 process->setWorkingDirectory(workspace.path.toString());
-                process->start(QLatin1String("bash"), QStringList() << QLatin1String("-c") << QLatin1String("catkin init"));
+                process->start(QLatin1String("bash"),
+                               QStringList() << QLatin1String("-c") << QLatin1String("catkin init"));
 
-                if( !process->waitForFinished() )
+                if (!process->waitForFinished())
                     return false;
 
                 break;
             }
-            case Colcon:
-            {
+            case Colcon: {
                 workspace = ROSUtils::getWorkspaceInfo(workspace.path,
                                                        workspace.buildSystem,
                                                        workspace.rosDistribution);
 
-                if( !initializeWorkspaceFolders(workspace) )
+                if (!initializeWorkspaceFolders(workspace))
                     return false;
 
                 break;
             }
-         }
+            }
 
-        if (process->exitStatus() != QProcess::CrashExit)
-            return buildWorkspace(process, workspace);
+            if (process->exitStatus() != QProcess::CrashExit)
+                return buildWorkspace(process, workspace);
 
-        Core::MessageManager::write(QObject::tr("[ROS Warning] Failed to initialize workspace: %1.").arg(workspace.path.toString()));
-        return false;
-    }
+            Core::MessageManager::write(
+                QObject::tr("[ROS Warning] Failed to initialize workspace: %1.")
+                    .arg(workspace.path.toString()));
+            return false;
+        }
 
     return true;
 }
 
 bool ROSUtils::buildWorkspace(QProcess *process, const WorkspaceInfo &workspaceInfo)
 {
-    switch(workspaceInfo.buildSystem) {
-    case CatkinMake:
-    {
+    switch (workspaceInfo.buildSystem) {
+    case CatkinMake: {
         process->setWorkingDirectory(workspaceInfo.path.toString());
-        process->start(QLatin1String("bash"), QStringList() << QLatin1String("-c") << QLatin1String("catkin_make --cmake-args -G \"CodeBlocks - Unix Makefiles\""));
+        process->start(QLatin1String("bash"),
+                       QStringList()
+                           << QLatin1String("-c")
+                           << QLatin1String(
+                                  "catkin_make --cmake-args -G \"CodeBlocks - Unix Makefiles\""));
         process->waitForFinished();
         break;
     }
-    case CatkinTools:
-    {
+    case CatkinTools: {
         process->setWorkingDirectory(workspaceInfo.path.toString());
-        process->start(QLatin1String("bash"), QStringList() << QLatin1String("-c") << QLatin1String("catkin build --cmake-args -G \"CodeBlocks - Unix Makefiles\""));
+        process->start(QLatin1String("bash"),
+                       QStringList()
+                           << QLatin1String("-c")
+                           << QLatin1String(
+                                  "catkin build --cmake-args -G \"CodeBlocks - Unix Makefiles\""));
         process->waitForFinished();
         break;
     }
-    case Colcon:
-    {
+    case Colcon: {
         process->setWorkingDirectory(workspaceInfo.path.toString());
-        process->start(QLatin1String("bash"), QStringList() << QLatin1String("-c") << QLatin1String("colcon build --cmake-args -G \"CodeBlocks - Unix Makefiles\""));
+        process->start(QLatin1String("bash"),
+                       QStringList()
+                           << QLatin1String("-c")
+                           << QLatin1String(
+                                  "colcon build --cmake-args -G \"CodeBlocks - Unix Makefiles\""));
         process->waitForFinished();
         break;
     }
@@ -257,84 +278,82 @@ bool ROSUtils::buildWorkspace(QProcess *process, const WorkspaceInfo &workspaceI
     if (process->exitStatus() != QProcess::CrashExit)
         return true;
 
-    Core::MessageManager::write(QObject::tr("[ROS Warning] Failed to build workspace: %1.").arg(workspaceInfo.path.toString()));
+    Core::MessageManager::write(QObject::tr("[ROS Warning] Failed to build workspace: %1.")
+                                    .arg(workspaceInfo.path.toString()));
     return false;
 }
 
 QList<Utils::FilePath> ROSUtils::installedDistributions()
 {
-  QSharedPointer<ROSSettings> ros_settings = ROSProjectPlugin::instance()->settings();
-  Utils::FilePath custom_ros_path = Utils::FilePath::fromString(ros_settings->custom_dist_path);
-  QList<Utils::FilePath> distributions;
-  if(custom_ros_path.exists())
-  {
-    QDir custom_dir(custom_ros_path.toString());
+    QSharedPointer<ROSSettings> ros_settings = ROSProjectPlugin::instance()->settings();
+    Utils::FilePath custom_ros_path = Utils::FilePath::fromString(ros_settings->custom_dist_path);
+    QList<Utils::FilePath> distributions;
+    if (custom_ros_path.exists()) {
+        QDir custom_dir(custom_ros_path.toString());
 
-    custom_dir.setFilter(QDir::NoDotAndDotDot | QDir::Dirs);
-    for (auto entry : custom_dir.entryList())
-    {
-      Utils::FilePath path(custom_ros_path);
-      path = path.pathAppended(entry);
+        custom_dir.setFilter(QDir::NoDotAndDotDot | QDir::Dirs);
+        for (auto entry : custom_dir.entryList()) {
+            Utils::FilePath path(custom_ros_path);
+            path = path.pathAppended(entry);
 
-      Utils::FilePath setup_file = path.pathAppended(QLatin1String("setup.bash"));
+            Utils::FilePath setup_file = path.pathAppended(QLatin1String("setup.bash"));
 
-      if (setup_file.exists())
-      {
-        distributions.append(path);
-      }
+            if (setup_file.exists()) {
+                distributions.append(path);
+            }
+        }
     }
-  }
 
-  Utils::FilePath default_ros_path = Utils::FilePath::fromString(ros_settings->default_dist_path);
-  if (default_ros_path.exists())
-  {
-    QDir ros_opt(default_ros_path.toString());
+    Utils::FilePath default_ros_path = Utils::FilePath::fromString(ros_settings->default_dist_path);
+    if (default_ros_path.exists()) {
+        QDir ros_opt(default_ros_path.toString());
 
-    ros_opt.setFilter(QDir::NoDotAndDotDot | QDir::Dirs);
-    for (auto entry : ros_opt.entryList())
-    {
-      Utils::FilePath path = Utils::FilePath::fromString(QLatin1String(ROSProjectManager::Constants::ROS_INSTALL_DIRECTORY));
-      path = path.pathAppended(entry);
+        ros_opt.setFilter(QDir::NoDotAndDotDot | QDir::Dirs);
+        for (auto entry : ros_opt.entryList()) {
+            Utils::FilePath path = Utils::FilePath::fromString(
+                QLatin1String(ROSProjectManager::Constants::ROS_INSTALL_DIRECTORY));
+            path = path.pathAppended(entry);
 
-      Utils::FilePath setup_file = path.pathAppended(QLatin1String("setup.bash"));
+            Utils::FilePath setup_file = path.pathAppended(QLatin1String("setup.bash"));
 
-      if (setup_file.exists())
-      {
-        distributions.append(path);
-      }
+            if (setup_file.exists()) {
+                distributions.append(path);
+            }
+        }
     }
-  }
 
-  if (distributions.isEmpty())
-      Core::MessageManager::write(QObject::tr("[ROS Error] ROS Does not appear to be installed.\n Check ROS Settings page to verify that the install location is valid."));
+    if (distributions.isEmpty())
+        Core::MessageManager::write(
+            QObject::tr("[ROS Error] ROS Does not appear to be installed.\n Check ROS Settings "
+                        "page to verify that the install location is valid."));
 
-  return distributions;
+    return distributions;
 }
 
 bool ROSUtils::sourceWorkspaceHelper(QProcess *process, const QString &path)
 {
-  QStringList env_list;
-  QString cmd = QLatin1String("source ") + path + QLatin1String(" && env");
+    QStringList env_list;
+    QString cmd = QLatin1String("source ") + path + QLatin1String(" && env");
 
-  process->start(QLatin1String("bash"));
-  process->waitForStarted();
-  process->write(cmd.toLatin1());
-  process->closeWriteChannel();
-  process->waitForFinished();
+    process->start(QLatin1String("bash"));
+    process->waitForStarted();
+    process->write(cmd.toLatin1());
+    process->closeWriteChannel();
+    process->waitForFinished();
 
-  if (process->exitStatus() != QProcess::CrashExit)
-  {
-    QString output = QString::fromStdString(process->readAllStandardOutput().toStdString());
-    env_list = output.split(QRegExp("[\r\n]"), QString::SkipEmptyParts);
+    if (process->exitStatus() != QProcess::CrashExit) {
+        QString output = QString::fromStdString(process->readAllStandardOutput().toStdString());
+        env_list = output.split(QRegExp("[\r\n]"), QString::SkipEmptyParts);
 
-    Utils::Environment env(env_list);
-    process->setProcessEnvironment(env.toProcessEnvironment());
-    return true;
-  }
-  return false;
+        Utils::Environment env(env_list);
+        process->setProcessEnvironment(env.toProcessEnvironment());
+        return true;
+    }
+    return false;
 }
 
-bool ROSUtils::gererateQtCreatorWorkspaceFile(QXmlStreamWriter &xmlFile, const ROSProjectFileContent &content)
+bool ROSUtils::gererateQtCreatorWorkspaceFile(QXmlStreamWriter &xmlFile,
+                                              const ROSProjectFileContent &content)
 {
     xmlFile.setAutoFormatting(true);
     xmlFile.writeStartDocument();
@@ -349,7 +368,7 @@ bool ROSUtils::gererateQtCreatorWorkspaceFile(QXmlStreamWriter &xmlFile, const R
     xmlFile.writeEndElement();
 
     xmlFile.writeStartElement(QLatin1String("WatchDirectories"));
-    for (const QString& str : content.watchDirectories)
+    for (const QString &str : content.watchDirectories)
         xmlFile.writeTextElement(QLatin1String("Directory"), str);
 
     xmlFile.writeEndElement();
@@ -359,64 +378,61 @@ bool ROSUtils::gererateQtCreatorWorkspaceFile(QXmlStreamWriter &xmlFile, const R
     return xmlFile.hasError();
 }
 
-bool ROSUtils::parseQtCreatorWorkspaceFile(const Utils::FilePath &filePath, ROSProjectFileContent &content)
+bool ROSUtils::parseQtCreatorWorkspaceFile(const Utils::FilePath &filePath,
+                                           ROSProjectFileContent &content)
 {
     QXmlStreamReader workspaceXml;
     QFile workspaceFile(filePath.toString());
-    if (workspaceFile.open(QFile::ReadOnly | QFile::Text))
-    {
+    if (workspaceFile.open(QFile::ReadOnly | QFile::Text)) {
         content.watchDirectories.clear();
 
         workspaceXml.setDevice(&workspaceFile);
-        while(workspaceXml.readNextStartElement())
-        {
-            if (workspaceXml.name() == QLatin1String("Distribution"))
-            {
+        while (workspaceXml.readNextStartElement()) {
+            if (workspaceXml.name() == QLatin1String("Distribution")) {
                 QList<Utils::FilePath> distributions = ROSUtils::installedDistributions();
                 QXmlStreamAttributes attributes = workspaceXml.attributes();
-                if (attributes.hasAttribute(QLatin1String("path")))
-                {
-                    content.distribution = Utils::FilePath::fromString(attributes.value(QLatin1String("path")).toString());
-                    if (!distributions.empty() && !distributions.contains(content.distribution))
-                    {
-                        Core::MessageManager::write(QObject::tr("[ROS Error] Project file distribution [%1] is not installed. Setting to [%2], if incorrect modify project file [%3].").arg(content.distribution.toString(), distributions.first().toString(), filePath.fileName()));
+                if (attributes.hasAttribute(QLatin1String("path"))) {
+                    content.distribution = Utils::FilePath::fromString(
+                        attributes.value(QLatin1String("path")).toString());
+                    if (!distributions.empty() && !distributions.contains(content.distribution)) {
+                        Core::MessageManager::write(
+                            QObject::tr(
+                                "[ROS Error] Project file distribution [%1] is not installed. "
+                                "Setting to [%2], if incorrect modify project file [%3].")
+                                .arg(content.distribution.toString(),
+                                     distributions.first().toString(),
+                                     filePath.fileName()));
                         content.distribution = distributions.first();
                     }
-                }
-                else
-                {
-                    if (!distributions.isEmpty())
-                    {
+                } else {
+                    if (!distributions.isEmpty()) {
                         content.distribution = distributions.first();
-                        Core::MessageManager::write(QObject::tr("[ROS Error] Unable to find ROS distributions."));
-                    }
-                    else
-                    {
-                        Core::MessageManager::write(QObject::tr("[ROS Error] Project file Distribution tag did not have a name attribute."));
+                        Core::MessageManager::write(
+                            QObject::tr("[ROS Error] Unable to find ROS distributions."));
+                    } else {
+                        Core::MessageManager::write(
+                            QObject::tr("[ROS Error] Project file Distribution tag did not have a "
+                                        "name attribute."));
                     }
                 }
 
                 workspaceXml.readNextStartElement();
-            }
-            else if (workspaceXml.name() == QLatin1String("DefaultBuildSystem"))
-            {
+            } else if (workspaceXml.name() == QLatin1String("DefaultBuildSystem")) {
                 QXmlStreamAttributes attributes = workspaceXml.attributes();
-                if (attributes.hasAttribute(QLatin1String("value")))
-                {
-                    content.defaultBuildSystem = (ROSUtils::BuildSystem)attributes.value(QLatin1String("value")).toInt();
-                }
-                else
-                {
+                if (attributes.hasAttribute(QLatin1String("value"))) {
+                    content.defaultBuildSystem
+                        = (ROSUtils::BuildSystem) attributes.value(QLatin1String("value")).toInt();
+                } else {
                     content.defaultBuildSystem = ROSUtils::CatkinMake;
-                    Core::MessageManager::write(QObject::tr("[ROS Warning] Project file DefaultBuildSystem tag did not have a value attribute."));
+                    Core::MessageManager::write(
+                        QObject::tr("[ROS Warning] Project file DefaultBuildSystem tag did not "
+                                    "have a value attribute."));
                 }
 
                 workspaceXml.readNextStartElement();
-            }
-            else if (workspaceXml.name() == QLatin1String("WatchDirectories"))
-            {
-                while(workspaceXml.readNextStartElement())
-                    if(workspaceXml.name() == QLatin1String("Directory"))
+            } else if (workspaceXml.name() == QLatin1String("WatchDirectories")) {
+                while (workspaceXml.readNextStartElement())
+                    if (workspaceXml.name() == QLatin1String("Directory"))
                         content.watchDirectories.append(workspaceXml.readElementText());
             }
         }
@@ -428,31 +444,36 @@ bool ROSUtils::parseQtCreatorWorkspaceFile(const Utils::FilePath &filePath, ROSP
         return true;
     }
 
-    Core::MessageManager::write(QObject::tr("[ROS Error] Error opening Workspace Project File: %1.").arg(filePath.toString()));
+    Core::MessageManager::write(QObject::tr("[ROS Error] Error opening Workspace Project File: %1.")
+                                    .arg(filePath.toString()));
     return false;
 }
 
-void ROSUtils::getDefaultFolderContentFilters(QStringList& folderNameFilters, QStringList& fileNameFilters)
+void ROSUtils::getDefaultFolderContentFilters(QStringList &folderNameFilters,
+                                              QStringList &fileNameFilters)
 {
-  folderNameFilters.push_back("\\.git");
-  fileNameFilters.push_back("^.*\\.autosave");
+    folderNameFilters.push_back("\\.git");
+    fileNameFilters.push_back("^.*\\.autosave");
 }
 
-ROSUtils::FolderContent ROSUtils::getFolderContent(const QString &folder, const QStringList& folderNameFilters, const QStringList& fileNameFilters)
+ROSUtils::FolderContent ROSUtils::getFolderContent(const QString &folder,
+                                                   const QStringList &folderNameFilters,
+                                                   const QStringList &fileNameFilters)
 {
-  ROSUtils::FolderContent content;
+    ROSUtils::FolderContent content;
 
-  // Get Directory data
-  content.directories = QDir(folder).entryList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Hidden);
-  content.removeDirectories(folderNameFilters);
+    // Get Directory data
+    content.directories = QDir(folder).entryList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Hidden);
+    content.removeDirectories(folderNameFilters);
 
-  content.files = QDir(folder).entryList(QDir::NoDotAndDotDot | QDir::Files | QDir::Hidden);
-  content.removeFiles(fileNameFilters);
+    content.files = QDir(folder).entryList(QDir::NoDotAndDotDot | QDir::Files | QDir::Hidden);
+    content.removeFiles(fileNameFilters);
 
-  return content;
+    return content;
 }
 
-QHash<QString, ROSUtils::FolderContent> ROSUtils::getFolderContentRecurisve(const Utils::FilePath &folderPath, QStringList &fileList, QStringList& directoryList)
+QHash<QString, ROSUtils::FolderContent> ROSUtils::getFolderContentRecurisve(
+    const Utils::FilePath &folderPath, QStringList &fileList, QStringList &directoryList)
 {
     QHash<QString, ROSUtils::FolderContent> workspaceFiles;
 
@@ -466,74 +487,71 @@ QHash<QString, ROSUtils::FolderContent> ROSUtils::getFolderContentRecurisve(cons
 
     workspaceFiles[folder] = content;
 
-    for (const QString& file : content.files)
+    for (const QString &file : content.files)
         fileList.append(QDir(folder).absoluteFilePath(file));
 
-    for (const QString& directory : content.directories)
+    for (const QString &directory : content.directories)
         directoryList.append(QDir(folder).absoluteFilePath(directory));
 
     // Get SubDirectory Information
     const QDir subDir(folder);
-    QDirIterator itSrc(subDir.absolutePath(), QDir::NoDotAndDotDot | QDir::Dirs | QDir::Hidden, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
+    QDirIterator itSrc(subDir.absolutePath(),
+                       QDir::NoDotAndDotDot | QDir::Dirs | QDir::Hidden,
+                       QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
     QList<QString> excludeDir;
-    while (itSrc.hasNext())
-    {
+    while (itSrc.hasNext()) {
         folder = itSrc.next();
 
         QString folder_name = Utils::FilePath::fromString(folder).fileName();
         bool found = false;
-        for (auto filter : folderNameFilters)
-        {
-          QRegularExpression rx(filter);
-          if (rx.match(folder_name).hasMatch())
-          {
-            excludeDir.push_back(folder + QLatin1Char('/'));
-            found = true;
-            break;
-          }
+        for (auto filter : folderNameFilters) {
+            QRegularExpression rx(filter);
+            if (rx.match(folder_name).hasMatch()) {
+                excludeDir.push_back(folder + QLatin1Char('/'));
+                found = true;
+                break;
+            }
         }
 
         if (found)
-          continue;
+            continue;
 
         bool skip = false;
-        for (const QString& exclude : excludeDir)
-        {
-            if (folder.startsWith(exclude))
-            {
+        for (const QString &exclude : excludeDir) {
+            if (folder.startsWith(exclude)) {
                 skip = true;
                 break;
             }
         }
 
-        if (skip) continue;
+        if (skip)
+            continue;
 
         content = getFolderContent(folder, folderNameFilters, fileNameFilters);
 
         workspaceFiles[folder] = content;
 
-        for (const QString& file : content.files)
+        for (const QString &file : content.files)
             fileList.append(QDir(folder).absoluteFilePath(file));
 
-        for (const QString& directory : content.directories)
+        for (const QString &directory : content.directories)
             directoryList.append(QDir(folder).absoluteFilePath(directory));
     }
 
     return workspaceFiles;
 }
 
-ROSUtils::PackageInfoMap ROSUtils::getWorkspacePackageInfo(const WorkspaceInfo &workspaceInfo, const PackageInfoMap *cachedPackageInfo)
+ROSUtils::PackageInfoMap ROSUtils::getWorkspacePackageInfo(const WorkspaceInfo &workspaceInfo,
+                                                           const PackageInfoMap *cachedPackageInfo)
 {
     PackageInfoMap wsPackageInfo;
-    QMap<QString, QString> packages =  ROSUtils::getWorkspacePackagePaths(workspaceInfo);
+    QMap<QString, QString> packages = ROSUtils::getWorkspacePackagePaths(workspaceInfo);
 
-    for(const auto& it : packages)
-    {
+    for (const auto &it : packages) {
         Utils::FilePath pkgXml = Utils::FilePath::fromString(it).pathAppended("package.xml");
         ROSUtils::PackageInfo packageInfo;
         ROSPackageXmlParser pkgParser;
-        if (pkgParser.parsePackageXml(pkgXml, packageInfo))
-        {
+        if (pkgParser.parsePackageXml(pkgXml, packageInfo)) {
             if (packageInfo.metapackage)
                 continue;
 
@@ -542,12 +560,12 @@ ROSUtils::PackageInfoMap ROSUtils::getWorkspacePackageInfo(const WorkspaceInfo &
         }
 
         // Check if there is cached build info available
-        if (cachedPackageInfo)
-        {
+        if (cachedPackageInfo) {
             auto packIt = cachedPackageInfo->find(packageInfo.name);
-            if (packIt != cachedPackageInfo->end())
-            {
-                Core::MessageManager::write(QObject::tr("[ROS Info] Using cached package information for package: %1.").arg(packageInfo.name));
+            if (packIt != cachedPackageInfo->end()) {
+                Core::MessageManager::write(
+                    QObject::tr("[ROS Info] Using cached package information for package: %1.")
+                        .arg(packageInfo.name));
                 wsPackageInfo.insert(packIt.value().name, packIt.value());
             }
         }
@@ -555,305 +573,281 @@ ROSUtils::PackageInfoMap ROSUtils::getWorkspacePackageInfo(const WorkspaceInfo &
     return wsPackageInfo;
 }
 
-ROSUtils::PackageBuildInfoMap ROSUtils::getWorkspacePackageBuildInfo(const WorkspaceInfo &workspaceInfo,
-                                                                     const PackageInfoMap &packageInfo,
-                                                                     const PackageBuildInfoMap *cachedPackageBuildInfo)
+ROSUtils::PackageBuildInfoMap ROSUtils::getWorkspacePackageBuildInfo(
+    const WorkspaceInfo &workspaceInfo,
+    const PackageInfoMap &packageInfo,
+    const PackageBuildInfoMap *cachedPackageBuildInfo)
 {
     PackageBuildInfoMap wsBuildInfo;
-    for (const PackageInfo& package : packageInfo)
-    {
+    for (const PackageInfo &package : packageInfo) {
         PackageBuildInfo buildInfo(package);
-        if (findPackageBuildDirectory(workspaceInfo, package, buildInfo.path))
-        {
+        if (findPackageBuildDirectory(workspaceInfo, package, buildInfo.path)) {
             // Get package's code block file
             buildInfo.cbpFile = buildInfo.path.pathAppended(QString("%1.cbp").arg(package.name));
 
             // If does not exist for default Project.cbp file
-            if (!buildInfo.cbpFile.exists())
-            {
-              Utils::FilePath temp = buildInfo.path.pathAppended("Project.cbp");
-              if (temp.exists())
-                  buildInfo.cbpFile = temp;
+            if (!buildInfo.cbpFile.exists()) {
+                Utils::FilePath temp = buildInfo.path.pathAppended("Project.cbp");
+                if (temp.exists())
+                    buildInfo.cbpFile = temp;
             }
 
-            if (buildInfo.cbpFile.exists())
-            {
-                if (ROSUtils::parseCodeBlocksFile(workspaceInfo, buildInfo))
-                {
+            if (buildInfo.cbpFile.exists()) {
+                if (ROSUtils::parseCodeBlocksFile(workspaceInfo, buildInfo)) {
                     wsBuildInfo.insert(package.name, buildInfo);
                     continue;
+                } else {
+                    Core::MessageManager::write(
+                        QObject::tr(
+                            "[ROS Warning] Unable to parse build information for package: %1.")
+                            .arg(package.name));
                 }
-                else
-                {
-                    Core::MessageManager::write(QObject::tr("[ROS Warning] Unable to parse build information for package: %1.").arg(package.name));
-                }
+            } else {
+                Core::MessageManager::write(
+                    QObject::tr("[ROS Warning] Unable to locate package %1 build file: %2.")
+                        .arg(package.name, buildInfo.cbpFile.toString()));
             }
-            else
-            {
-                Core::MessageManager::write(QObject::tr("[ROS Warning] Unable to locate package %1 build file: %2.").arg(package.name, buildInfo.cbpFile.toString()));
-            }
-        }
-        else
-        {
-            Core::MessageManager::write(QObject::tr("[ROS Warning] Unable to locate build directory for package: %1.").arg(package.name));
+        } else {
+            Core::MessageManager::write(
+                QObject::tr("[ROS Warning] Unable to locate build directory for package: %1.")
+                    .arg(package.name));
         }
 
         // Check if there is cached build info available
-        if (cachedPackageBuildInfo)
-        {
+        if (cachedPackageBuildInfo) {
             auto packIt = cachedPackageBuildInfo->find(package.name);
-            if (packIt != cachedPackageBuildInfo->end())
-            {
-                Core::MessageManager::write(QObject::tr("[ROS Info] Using cached package build information for package: %1.").arg(package.name));
+            if (packIt != cachedPackageBuildInfo->end()) {
+                Core::MessageManager::write(
+                    QObject::tr(
+                        "[ROS Info] Using cached package build information for package: %1.")
+                        .arg(package.name));
                 wsBuildInfo.insert(package.name, packIt.value());
             }
         }
-
     }
 
     return wsBuildInfo;
 }
 
-bool ROSUtils::parseCodeBlocksFile(const WorkspaceInfo &workspaceInfo, ROSUtils::PackageBuildInfo &buildInfo)
+bool ROSUtils::parseCodeBlocksFile(const WorkspaceInfo &workspaceInfo,
+                                   ROSUtils::PackageBuildInfo &buildInfo)
 {
-  QMap<QString, PackageTargetInfo*> targetMap;
+    QMap<QString, PackageTargetInfo *> targetMap;
 
-  // Parse CodeBlocks Project File
-  // Need to search for all of the tags <Add directory="include path" />
-  QXmlStreamReader cbpXml;
+    // Parse CodeBlocks Project File
+    // Need to search for all of the tags <Add directory="include path" />
+    QXmlStreamReader cbpXml;
 
-  QFile cbpFile(buildInfo.cbpFile.toString());
-  if (!cbpFile.open(QFile::ReadOnly | QFile::Text))
-  {
-    Core::MessageManager::write(QObject::tr("[ROS Error] Error opening CodeBlocks Project File: %1.").arg(buildInfo.cbpFile.toString()));
-    return false;
-  }
-
-  // make sure targets are cleared
-  buildInfo.targets.clear();
-
-  // build time include directory
-  Utils::FilePath buildtimeInclude(workspaceInfo.develPath);
-  if (workspaceInfo.install)
-    buildtimeInclude = Utils::FilePath(workspaceInfo.installPath);
-
-  buildtimeInclude = buildtimeInclude.pathAppended(QLatin1String("include"));
-
-  cbpXml.setDevice(&cbpFile);
-  cbpXml.readNext();
-  while(!cbpXml.atEnd())
-  {
-    if(cbpXml.isStartElement())
-    {
-      if(cbpXml.name() == QLatin1String("Target"))
-      {
-        QString targetName;
-        QString targetWorkingDir = buildInfo.path.toString();
-        QStringList targetLocalIncludes;
-        QStringList targetSystemIncludes;
-        TargetType targetType = UtilityType;
-        if (cbpXml.attributes().hasAttribute("title"))
-        {
-          QString title =cbpXml.attributes().value("title").toString();
-          if (!title.endsWith(QLatin1String("/fast")) && !title.endsWith(QLatin1String("_automoc")) && !title.startsWith(QLatin1String("gtest")))
-          {
-            targetName = title;
-          }
-          else
-          {
-            cbpXml.readNext();
-            continue;
-          }
-        }
-        else
-        {
-          cbpXml.readNext();
-          continue;
-        }
-
-        cbpXml.readNext();
-        while (cbpXml.name() != QLatin1String("Target"))
-        {
-            if(cbpXml.isStartElement())
-            {
-                if(cbpXml.name() == QLatin1String("Option"))
-                {
-                    if (cbpXml.attributes().hasAttribute("type"))
-                    {
-                        QString attribute_value = cbpXml.attributes().value("type").toString();
-                        if (attribute_value == "0" || attribute_value == "1")
-                            targetType = ExecutableType;
-                        else if (attribute_value == "2")
-                            targetType = StaticLibraryType;
-                        else if (attribute_value == "3")
-                            targetType = DynamicLibraryType;
-                        else
-                            targetType = UtilityType;
-                    }
-
-                    if (cbpXml.attributes().hasAttribute("working_dir"))
-                    {
-                        targetWorkingDir = cbpXml.attributes().value("working_dir").toString();
-                    }
-                }
-
-                if(cbpXml.name() == QLatin1String("Add"))
-                {
-                    if (cbpXml.attributes().hasAttribute("directory"))
-                    {
-                        QString attribute_value = cbpXml.attributes().value("directory").toString();
-                        if (attribute_value.startsWith(workspaceInfo.path.toString()))
-                        {
-                            if (!targetLocalIncludes.contains(attribute_value))
-                              targetLocalIncludes.append(attribute_value);
-                        }
-                        else if(!targetSystemIncludes.contains(attribute_value))
-                        {
-                            targetSystemIncludes.append(attribute_value);
-                        }
-                    }
-                }
-            }
-            cbpXml.readNext();
-        }
-
-        // Only need to add target types ExecutableType and StaticLibraryType to the code model
-        if (targetType != UtilityType)
-        {
-            targetLocalIncludes.append(buildtimeInclude.toString());
-
-            PackageTargetInfo targetInfo;
-            targetInfo.name = targetName;
-            targetInfo.type = targetType;
-            targetInfo.flagsFile = Utils::FilePath::fromString(targetWorkingDir).pathAppended("CMakeFiles").pathAppended(QString("%1.dir").arg(targetName)).pathAppended("flags.make");
-            if (!targetInfo.flagsFile.exists())
-            {
-                QDirIterator it(buildInfo.path.toString(), QStringList() << QString("%1.dir").arg(targetName), QDir::NoFilter, QDirIterator::Subdirectories);
-                while (it.hasNext())
-                {
-                    Utils::FilePath found_path = Utils::FilePath::fromString(it.next()).pathAppended("flags.make");
-                    if (found_path.exists())
-                    {
-                      targetInfo.flagsFile = found_path;
-                      break;
-                    }
-                }
-            }
-
-            // The order matters so it will order local first then system
-            targetInfo.includes = targetLocalIncludes;
-            targetInfo.includes.append(targetSystemIncludes);
-
-            buildInfo.targets.append(targetInfo);
-            targetMap[targetName] = &(buildInfo.targets.back());
-        }
-      }
-      else if(cbpXml.name() == QLatin1String("Unit"))
-      {
-        QString filename;
-        if (cbpXml.attributes().hasAttribute("filename"))
-        {
-            filename = cbpXml.attributes().value("filename").toString();
-        }
-        cbpXml.readNext();
-        while (cbpXml.name() != QLatin1String("Unit"))
-        {
-            if(cbpXml.isStartElement())
-            {
-                if(cbpXml.name() == QLatin1String("Option"))
-                {
-                    if (cbpXml.attributes().hasAttribute("target"))
-                    {
-                        QString temp = cbpXml.attributes().value("target").toString();
-                        auto it = targetMap.find(temp);
-                        if (it != targetMap.end())
-                          it.value()->source_files.append(filename);
-                    }
-                }
-            }
-            cbpXml.readNext();
-        }
-      }
+    QFile cbpFile(buildInfo.cbpFile.toString());
+    if (!cbpFile.open(QFile::ReadOnly | QFile::Text)) {
+        Core::MessageManager::write(
+            QObject::tr("[ROS Error] Error opening CodeBlocks Project File: %1.")
+                .arg(buildInfo.cbpFile.toString()));
+        return false;
     }
+
+    // make sure targets are cleared
+    buildInfo.targets.clear();
+
+    // build time include directory
+    Utils::FilePath buildtimeInclude(workspaceInfo.develPath);
+    if (workspaceInfo.install)
+        buildtimeInclude = Utils::FilePath(workspaceInfo.installPath);
+
+    buildtimeInclude = buildtimeInclude.pathAppended(QLatin1String("include"));
+
+    cbpXml.setDevice(&cbpFile);
     cbpXml.readNext();
-  }
+    while (!cbpXml.atEnd()) {
+        if (cbpXml.isStartElement()) {
+            if (cbpXml.name() == QLatin1String("Target")) {
+                QString targetName;
+                QString targetWorkingDir = buildInfo.path.toString();
+                QStringList targetLocalIncludes;
+                QStringList targetSystemIncludes;
+                TargetType targetType = UtilityType;
+                if (cbpXml.attributes().hasAttribute("title")) {
+                    QString title = cbpXml.attributes().value("title").toString();
+                    if (!title.endsWith(QLatin1String("/fast"))
+                        && !title.endsWith(QLatin1String("_automoc"))
+                        && !title.startsWith(QLatin1String("gtest"))) {
+                        targetName = title;
+                    } else {
+                        cbpXml.readNext();
+                        continue;
+                    }
+                } else {
+                    cbpXml.readNext();
+                    continue;
+                }
 
-//  Next search the package directory for any missed include folders
-//  QString includePath;
-//  QDirIterator itPackage(package.path, QStringList() << QLatin1String("include"), QDir::Dirs | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
-//  while (itPackage.hasNext())
-//  {
-//    includePath = itPackage.next();
-//    if(!workspace_includes.contains(includePath))
-//      workspace_includes.append(includePath);
-//  }
+                cbpXml.readNext();
+                while (cbpXml.name() != QLatin1String("Target")) {
+                    if (cbpXml.isStartElement()) {
+                        if (cbpXml.name() == QLatin1String("Option")) {
+                            if (cbpXml.attributes().hasAttribute("type")) {
+                                QString attribute_value
+                                    = cbpXml.attributes().value("type").toString();
+                                if (attribute_value == "0" || attribute_value == "1")
+                                    targetType = ExecutableType;
+                                else if (attribute_value == "2")
+                                    targetType = StaticLibraryType;
+                                else if (attribute_value == "3")
+                                    targetType = DynamicLibraryType;
+                                else
+                                    targetType = UtilityType;
+                            }
 
-  for(auto it = buildInfo.targets.begin(); it != buildInfo.targets.end(); ++it)
-  {
-      // Next need to parse flags.cmake for flags and defines
-      if (it->flagsFile.exists())
-      {
-          QFile flagsFile(it->flagsFile.toString());
-          if (!flagsFile.open(QFile::ReadOnly | QFile::Text))
-          {
-            Core::MessageManager::write(QObject::tr("[ROS Error] Error opening flags file: %1.").arg(it->flagsFile.toString()));
+                            if (cbpXml.attributes().hasAttribute("working_dir")) {
+                                targetWorkingDir
+                                    = cbpXml.attributes().value("working_dir").toString();
+                            }
+                        }
+
+                        if (cbpXml.name() == QLatin1String("Add")) {
+                            if (cbpXml.attributes().hasAttribute("directory")) {
+                                QString attribute_value
+                                    = cbpXml.attributes().value("directory").toString();
+                                if (attribute_value.startsWith(workspaceInfo.path.toString())) {
+                                    if (!targetLocalIncludes.contains(attribute_value))
+                                        targetLocalIncludes.append(attribute_value);
+                                } else if (!targetSystemIncludes.contains(attribute_value)) {
+                                    targetSystemIncludes.append(attribute_value);
+                                }
+                            }
+                        }
+                    }
+                    cbpXml.readNext();
+                }
+
+                // Only need to add target types ExecutableType and StaticLibraryType to the code model
+                if (targetType != UtilityType) {
+                    targetLocalIncludes.append(buildtimeInclude.toString());
+
+                    PackageTargetInfo targetInfo;
+                    targetInfo.name = targetName;
+                    targetInfo.type = targetType;
+                    targetInfo.flagsFile = Utils::FilePath::fromString(targetWorkingDir)
+                                               .pathAppended("CMakeFiles")
+                                               .pathAppended(QString("%1.dir").arg(targetName))
+                                               .pathAppended("flags.make");
+                    if (!targetInfo.flagsFile.exists()) {
+                        QDirIterator it(buildInfo.path.toString(),
+                                        QStringList() << QString("%1.dir").arg(targetName),
+                                        QDir::NoFilter,
+                                        QDirIterator::Subdirectories);
+                        while (it.hasNext()) {
+                            Utils::FilePath found_path = Utils::FilePath::fromString(it.next())
+                                                             .pathAppended("flags.make");
+                            if (found_path.exists()) {
+                                targetInfo.flagsFile = found_path;
+                                break;
+                            }
+                        }
+                    }
+
+                    // The order matters so it will order local first then system
+                    targetInfo.includes = targetLocalIncludes;
+                    targetInfo.includes.append(targetSystemIncludes);
+
+                    buildInfo.targets.append(targetInfo);
+                    targetMap[targetName] = &(buildInfo.targets.back());
+                }
+            } else if (cbpXml.name() == QLatin1String("Unit")) {
+                QString filename;
+                if (cbpXml.attributes().hasAttribute("filename")) {
+                    filename = cbpXml.attributes().value("filename").toString();
+                }
+                cbpXml.readNext();
+                while (cbpXml.name() != QLatin1String("Unit")) {
+                    if (cbpXml.isStartElement()) {
+                        if (cbpXml.name() == QLatin1String("Option")) {
+                            if (cbpXml.attributes().hasAttribute("target")) {
+                                QString temp = cbpXml.attributes().value("target").toString();
+                                auto it = targetMap.find(temp);
+                                if (it != targetMap.end())
+                                    it.value()->source_files.append(filename);
+                            }
+                        }
+                    }
+                    cbpXml.readNext();
+                }
+            }
+        }
+        cbpXml.readNext();
+    }
+
+    //  Next search the package directory for any missed include folders
+    //  QString includePath;
+    //  QDirIterator itPackage(package.path, QStringList() << QLatin1String("include"), QDir::Dirs | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
+    //  while (itPackage.hasNext())
+    //  {
+    //    includePath = itPackage.next();
+    //    if(!workspace_includes.contains(includePath))
+    //      workspace_includes.append(includePath);
+    //  }
+
+    for (auto it = buildInfo.targets.begin(); it != buildInfo.targets.end(); ++it) {
+        // Next need to parse flags.cmake for flags and defines
+        if (it->flagsFile.exists()) {
+            QFile flagsFile(it->flagsFile.toString());
+            if (!flagsFile.open(QFile::ReadOnly | QFile::Text)) {
+                Core::MessageManager::write(QObject::tr("[ROS Error] Error opening flags file: %1.")
+                                                .arg(it->flagsFile.toString()));
+                it->flags.append(QLatin1String("-std=c++11"));
+                continue;
+            }
+
+            QTextStream flagsStream(&flagsFile);
+            while (!flagsStream.atEnd()) {
+                QString line = flagsStream.readLine().trimmed();
+                if (line.startsWith("CXX_FLAGS ="))
+                    it->flags = line.mid(11).trimmed().split(' ', QString::SkipEmptyParts);
+
+                QStringList defines;
+                if (line.startsWith("CXX_DEFINES ="))
+                    defines = line.mid(13).trimmed().split(' ', QString::SkipEmptyParts);
+
+                // Need to remove -D from the define and escaped quotes
+                for (auto &d : defines)
+                    it->defines.push_back(d.trimmed().mid(2).remove('\\'));
+            }
+        } else {
+            Core::MessageManager::write(QObject::tr("[ROS Warning] Flags file does not exist: %1.")
+                                            .arg(it->flagsFile.toString()));
             it->flags.append(QLatin1String("-std=c++11"));
-            continue;
-          }
+        }
+    }
 
-          QTextStream flagsStream(&flagsFile);
-          while (!flagsStream.atEnd()) {
-              QString line = flagsStream.readLine().trimmed();
-              if (line.startsWith("CXX_FLAGS ="))
-                  it->flags = line.mid(11).trimmed().split(' ', QString::SkipEmptyParts);
-
-              QStringList defines;
-              if (line.startsWith("CXX_DEFINES ="))
-                  defines = line.mid(13).trimmed().split(' ', QString::SkipEmptyParts);
-
-              // Need to remove -D from the define and escaped quotes
-              for (auto& d : defines)
-                  it->defines.push_back(d.trimmed().mid(2).remove('\\'));
-          }
-      }
-      else
-      {
-          Core::MessageManager::write(QObject::tr("[ROS Warning] Flags file does not exist: %1.").arg(it->flagsFile.toString()));
-          it->flags.append(QLatin1String("-std=c++11"));
-      }
-  }
-
-  return true;
+    return true;
 }
 
 QMap<QString, QString> ROSUtils::getROSPackages(const QStringList &env)
 {
-  QProcess process;
-  QMap<QString, QString> package_map;
-  QStringList tmp;
+    QProcess process;
+    QMap<QString, QString> package_map;
+    QStringList tmp;
 
-  process.setEnvironment(env);
-  process.start(QLatin1String("bash"));
-  process.waitForStarted();
-  QString cmd = QLatin1String("rospack list"); // TODO: for ROS2 do 'ros2 pkg list'
-  process.write(cmd.toLatin1());
-  process.closeWriteChannel();
-  process.waitForFinished();
+    process.setEnvironment(env);
+    process.start(QLatin1String("bash"));
+    process.waitForStarted();
+    QString cmd = QLatin1String("rospack list"); // TODO: for ROS2 do 'ros2 pkg list'
+    process.write(cmd.toLatin1());
+    process.closeWriteChannel();
+    process.waitForFinished();
 
-  if (process.exitStatus() != QProcess::CrashExit)
-  {
-    QString output = QString::fromStdString(process.readAllStandardOutput().toStdString());
-    QStringList package_list = output.split(QRegExp("[\r\n]"), QString::SkipEmptyParts);
+    if (process.exitStatus() != QProcess::CrashExit) {
+        QString output = QString::fromStdString(process.readAllStandardOutput().toStdString());
+        QStringList package_list = output.split(QRegExp("[\r\n]"), QString::SkipEmptyParts);
 
-    for (const QString& str : package_list)
-    {
-        tmp = str.split(QLatin1String(" "));
-        package_map.insert(tmp[0],tmp[1]);
+        for (const QString &str : package_list) {
+            tmp = str.split(QLatin1String(" "));
+            package_map.insert(tmp[0], tmp[1]);
+        }
+
+        return package_map;
     }
-
-    return package_map;
-  }
-  return QMap<QString, QString>();
+    return QMap<QString, QString>();
 }
 
 QMap<QString, QString> ROSUtils::getWorkspacePackagePaths(const WorkspaceInfo &workspaceInfo)
@@ -861,18 +855,20 @@ QMap<QString, QString> ROSUtils::getWorkspacePackagePaths(const WorkspaceInfo &w
     QMap<QString, QString> packageMap;
 
     const QDir srcDir(workspaceInfo.sourcePath.toString());
-    if(srcDir.exists())
-    {
-      QDirIterator it(srcDir.absolutePath(),QStringList() << QLatin1String("package.xml"), QDir::Files | QDir::NoDotAndDotDot, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
-      while (it.hasNext())
-      {
-        QFileInfo packageFile(it.next());
-        packageMap.insert(packageFile.absoluteDir().dirName(), packageFile.absoluteDir().absolutePath());
-      }
-    }
-    else
-    {
-        Core::MessageManager::write(QObject::tr("[ROS Error] Workspace source directory does not exist: %1.").arg(workspaceInfo.sourcePath.toString()));
+    if (srcDir.exists()) {
+        QDirIterator it(srcDir.absolutePath(),
+                        QStringList() << QLatin1String("package.xml"),
+                        QDir::Files | QDir::NoDotAndDotDot,
+                        QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
+        while (it.hasNext()) {
+            QFileInfo packageFile(it.next());
+            packageMap.insert(packageFile.absoluteDir().dirName(),
+                              packageFile.absoluteDir().absolutePath());
+        }
+    } else {
+        Core::MessageManager::write(
+            QObject::tr("[ROS Error] Workspace source directory does not exist: %1.")
+                .arg(workspaceInfo.sourcePath.toString()));
     }
 
     return packageMap;
@@ -880,57 +876,58 @@ QMap<QString, QString> ROSUtils::getWorkspacePackagePaths(const WorkspaceInfo &w
 
 QMap<QString, QString> ROSUtils::getROSPackageLaunchFiles(const QString &packagePath)
 {
-  QMap<QString, QString> launchFiles;
-  if(!packagePath.isEmpty())
-  {
-    const QDir srcDir(packagePath);
-    QDirIterator it(srcDir.absolutePath(),QStringList() << QLatin1String("*.launch"), QDir::Files | QDir::NoDotAndDotDot, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
+    QMap<QString, QString> launchFiles;
+    if (!packagePath.isEmpty()) {
+        const QDir srcDir(packagePath);
+        QDirIterator it(srcDir.absolutePath(),
+                        QStringList() << QLatin1String("*.launch"),
+                        QDir::Files | QDir::NoDotAndDotDot,
+                        QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
 
-    while (it.hasNext())
-    {
-      QFileInfo launchFile(it.next());
-      launchFiles.insert(launchFile.fileName(), launchFile.absoluteFilePath());
+        while (it.hasNext()) {
+            QFileInfo launchFile(it.next());
+            launchFiles.insert(launchFile.fileName(), launchFile.absoluteFilePath());
+        }
     }
-  }
 
-  return launchFiles;
+    return launchFiles;
 }
 
-QMap<QString, QString> ROSUtils::getROSPackageExecutables(const QString &packageName, const QStringList &env)
+QMap<QString, QString> ROSUtils::getROSPackageExecutables(const QString &packageName,
+                                                          const QStringList &env)
 {
+    QProcess process;
+    QMap<QString, QString> package_executables;
 
-  QProcess process;
-  QMap<QString, QString> package_executables;
+    process.setEnvironment(env);
+    process.start(QLatin1String("bash"));
+    process.waitForStarted();
+    QString cmd = QLatin1String("catkin_find --without-underlays --libexec ") + packageName;
+    process.write(cmd.toLatin1());
+    process.closeWriteChannel();
+    process.waitForFinished();
 
-  process.setEnvironment(env);
-  process.start(QLatin1String("bash"));
-  process.waitForStarted();
-  QString cmd = QLatin1String("catkin_find --without-underlays --libexec ") + packageName;
-  process.write(cmd.toLatin1());
-  process.closeWriteChannel();
-  process.waitForFinished();
+    if (process.exitStatus() != QProcess::CrashExit) {
+        QString output = QString::fromStdString(process.readAllStandardOutput().toStdString());
+        QStringList loc_list = output.split(QRegExp("[\r\n]"), QString::SkipEmptyParts);
 
-  if (process.exitStatus() != QProcess::CrashExit)
-  {
-    QString output = QString::fromStdString(process.readAllStandardOutput().toStdString());
-    QStringList loc_list = output.split(QRegExp("[\r\n]"), QString::SkipEmptyParts);
+        if (loc_list.size() > 0) {
+            const QDir srcDir(loc_list[0]);
+            QDirIterator it(srcDir.absolutePath(),
+                            QDir::Files | QDir::Executable | QDir::NoDotAndDotDot,
+                            QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
 
-    if (loc_list.size() > 0)
-    {
-      const QDir srcDir(loc_list[0]);
-      QDirIterator it(srcDir.absolutePath(), QDir::Files | QDir::Executable | QDir::NoDotAndDotDot, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
+            while (it.hasNext()) {
+                QFileInfo executableFile(it.next());
+                package_executables.insert(executableFile.fileName(),
+                                           executableFile.absoluteFilePath());
+            }
 
-      while (it.hasNext())
-      {
-        QFileInfo executableFile(it.next());
-        package_executables.insert(executableFile.fileName(), executableFile.absoluteFilePath());
-      }
-
-      return package_executables;
+            return package_executables;
+        }
     }
-  }
 
-  return QMap<QString, QString>();
+    return QMap<QString, QString>();
 }
 
 Utils::FilePath ROSUtils::getCatkinToolsProfilesPath(const Utils::FilePath &workspaceDir)
@@ -962,7 +959,7 @@ bool ROSUtils::setCatkinToolsProfilesYamlFile(const Utils::FilePath &workspaceDi
 
     std::ofstream fout(profiles.toString().toStdString());
 
-    if( ! fout.is_open())
+    if (!fout.is_open())
         return false;
 
     fout << config; // dump it back into the file
@@ -970,60 +967,61 @@ bool ROSUtils::setCatkinToolsProfilesYamlFile(const Utils::FilePath &workspaceDi
     return true;
 }
 
-Utils::FilePath ROSUtils::getCatkinToolsProfilePath(const Utils::FilePath &workspaceDir, const QString &profileName)
+Utils::FilePath ROSUtils::getCatkinToolsProfilePath(const Utils::FilePath &workspaceDir,
+                                                    const QString &profileName)
 {
     Utils::FilePath profile = getCatkinToolsProfilesPath(workspaceDir);
     profile = profile.pathAppended(profileName);
     return profile;
 }
 
-Utils::FilePath ROSUtils::getCatkinToolsProfileConfigFile(const Utils::FilePath &workspaceDir, const QString &profileName)
+Utils::FilePath ROSUtils::getCatkinToolsProfileConfigFile(const Utils::FilePath &workspaceDir,
+                                                          const QString &profileName)
 {
     Utils::FilePath profile = getCatkinToolsProfilePath(workspaceDir, profileName);
     profile = profile.pathAppended("config.yaml");
     return profile;
 }
 
-bool ROSUtils::isCatkinToolsProfileConfigValid(const Utils::FilePath& configPath)
+bool ROSUtils::isCatkinToolsProfileConfigValid(const Utils::FilePath &configPath)
 {
-  if (!configPath.exists())
-    return false;
+    if (!configPath.exists())
+        return false;
 
-  YAML::Node config = YAML::LoadFile(configPath.toString().toStdString());
-  if (config.IsNull())
-    return false;
+    YAML::Node config = YAML::LoadFile(configPath.toString().toStdString());
+    if (config.IsNull())
+        return false;
 
-  if (!config["source_space"].IsDefined())
-    return false;
+    if (!config["source_space"].IsDefined())
+        return false;
 
-  if (!config["build_space"].IsDefined())
-    return false;
+    if (!config["build_space"].IsDefined())
+        return false;
 
-  if (!config["devel_space"].IsDefined())
-    return false;
+    if (!config["devel_space"].IsDefined())
+        return false;
 
-  if (!config["install_space"].IsDefined())
-    return false;
+    if (!config["install_space"].IsDefined())
+        return false;
 
-  if (!config["log_space"].IsDefined())
-    return false;
+    if (!config["log_space"].IsDefined())
+        return false;
 
-  if (!config["install"].IsDefined())
-    return false;
+    if (!config["install"].IsDefined())
+        return false;
 
-  return true;
+    return true;
 }
 
-bool ROSUtils::removeCatkinToolsProfile(const Utils::FilePath &workspaceDir, const QString &profileName)
+bool ROSUtils::removeCatkinToolsProfile(const Utils::FilePath &workspaceDir,
+                                        const QString &profileName)
 {
     QString activeProfile = getCatkinToolsActiveProfile(workspaceDir);
 
-    if( activeProfile.length() )
-    {
+    if (activeProfile.length()) {
         Utils::FilePath profiles = getCatkinToolsProfilePath(workspaceDir, profileName);
         QDir d(profiles.toString());
-        if (d.exists())
-        {
+        if (d.exists()) {
             if (!d.removeRecursively())
                 return false;
 
@@ -1035,7 +1033,9 @@ bool ROSUtils::removeCatkinToolsProfile(const Utils::FilePath &workspaceDir, con
     return true;
 }
 
-bool ROSUtils::renameCatkinToolsProfile(const Utils::FilePath &workspaceDir, const QString &oldProfileName, const QString &newProfileName)
+bool ROSUtils::renameCatkinToolsProfile(const Utils::FilePath &workspaceDir,
+                                        const QString &oldProfileName,
+                                        const QString &newProfileName)
 {
     Utils::FilePath profile = getCatkinToolsProfilePath(workspaceDir, oldProfileName);
     QDir d(profile.toString());
@@ -1045,23 +1045,25 @@ bool ROSUtils::renameCatkinToolsProfile(const Utils::FilePath &workspaceDir, con
     return createCatkinToolsProfile(workspaceDir, newProfileName, true);
 }
 
-bool ROSUtils::createCatkinToolsProfile(const Utils::FilePath &workspaceDir, const QString profileName, bool overwrite)
+bool ROSUtils::createCatkinToolsProfile(const Utils::FilePath &workspaceDir,
+                                        const QString profileName,
+                                        bool overwrite)
 {
     Utils::FilePath config = getCatkinToolsProfileConfigFile(workspaceDir, profileName);
 
     QDir().mkpath(getCatkinToolsProfilePath(workspaceDir, profileName).toString());
     if (overwrite)
-      QFile::remove(config.toString());
+        QFile::remove(config.toString());
 
-    return (QFile::copy(":rosproject/config.yaml", config.toString()) &&
-            QFile::setPermissions(config.toString(),
-                                  QFile::ReadUser |
-                                  QFile::WriteUser |
-                                  QFile::ReadGroup |
-                                  QFile::WriteGroup));
+    return (QFile::copy(":rosproject/config.yaml", config.toString())
+            && QFile::setPermissions(config.toString(),
+                                     QFile::ReadUser | QFile::WriteUser | QFile::ReadGroup
+                                         | QFile::WriteGroup));
 }
 
-bool ROSUtils::cloneCatkinToolsProfile(const Utils::FilePath &workspaceDir, const QString &profileName, const QString &newProfileName)
+bool ROSUtils::cloneCatkinToolsProfile(const Utils::FilePath &workspaceDir,
+                                       const QString &profileName,
+                                       const QString &newProfileName)
 {
     Utils::FilePath copyConfig = getCatkinToolsProfileConfigFile(workspaceDir, profileName);
     Utils::FilePath newConfig = getCatkinToolsProfileConfigFile(workspaceDir, newProfileName);
@@ -1077,12 +1079,10 @@ QString ROSUtils::getCatkinToolsActiveProfile(const Utils::FilePath &workspaceDi
 {
     QString activeProfile;
     Utils::FilePath profiles = getCatkinToolsProfilesYamlFile(workspaceDir);
-    if (profiles.exists())
-    {
+    if (profiles.exists()) {
         YAML::Node config = YAML::LoadFile(profiles.toString().toStdString());
         activeProfile = QString::fromStdString(config["active"].as<std::string>());
-    }
-    else
+    } else
         return QString("");
 
     return activeProfile;
@@ -1098,12 +1098,13 @@ QString ROSUtils::setCatkinToolsDefaultProfile(const Utils::FilePath &workspaceD
     return defaultProfile;
 }
 
-bool ROSUtils::setCatkinToolsActiveProfile(const Utils::FilePath &workspaceDir, const QString &profileName)
+bool ROSUtils::setCatkinToolsActiveProfile(const Utils::FilePath &workspaceDir,
+                                           const QString &profileName)
 {
     // Create profiles directory if it does not exist
     QDir().mkpath(getCatkinToolsProfilesPath(workspaceDir).toString());
 
-    if( ! setCatkinToolsProfilesYamlFile(workspaceDir, profileName) )
+    if (!setCatkinToolsProfilesYamlFile(workspaceDir, profileName))
         return false;
 
     // This will create the profile if it does not exist with default config.
@@ -1115,8 +1116,7 @@ bool ROSUtils::setCatkinToolsActiveProfile(const Utils::FilePath &workspaceDir, 
 QStringList ROSUtils::getCatkinToolsProfileNames(const Utils::FilePath &workspaceDir)
 {
     Utils::FilePath profiles = getCatkinToolsProfilesPath(workspaceDir);
-    if (profiles.exists())
-    {
+    if (profiles.exists()) {
         QDir d(profiles.toString());
         QStringList profileNames = d.entryList(QDir::AllDirs | QDir::NoDotAndDotDot);
         if (!profileNames.empty())
@@ -1128,10 +1128,11 @@ QStringList ROSUtils::getCatkinToolsProfileNames(const Utils::FilePath &workspac
     return QStringList() << QLatin1String("default");
 }
 
-Utils::FilePath ROSUtils::getCatkinToolsProfile(const Utils::FilePath &workspaceDir, const QString &profileName)
+Utils::FilePath ROSUtils::getCatkinToolsProfile(const Utils::FilePath &workspaceDir,
+                                                const QString &profileName)
 {
     Utils::FilePath profile = ROSUtils::getCatkinToolsProfileConfigFile(workspaceDir, profileName);
-    if(!isCatkinToolsProfileConfigValid(profile))
+    if (!isCatkinToolsProfileConfigValid(profile))
         createCatkinToolsProfile(workspaceDir, profileName, true);
 
     return profile;
@@ -1162,9 +1163,8 @@ ROSUtils::WorkspaceInfo ROSUtils::getWorkspaceInfo(const Utils::FilePath &worksp
     space.buildSystem = buildSystem;
     space.rosDistribution = rosDistribution;
 
-    switch(buildSystem) {
-    case CatkinMake:
-    {
+    switch (buildSystem) {
+    case CatkinMake: {
         space.sourcePath = Utils::FilePath(workspaceDir).pathAppended("src");
         space.buildPath = Utils::FilePath(workspaceDir).pathAppended("build");
         space.develPath = Utils::FilePath(workspaceDir).pathAppended("devel");
@@ -1173,39 +1173,48 @@ ROSUtils::WorkspaceInfo ROSUtils::getWorkspaceInfo(const Utils::FilePath &worksp
         space.install = false; //TODO: Need to find how best to determine if installing
         break;
     }
-    case CatkinTools:
-    {
+    case CatkinTools: {
         YAML::Node config;
         QString activeProfile = getCatkinToolsActiveProfile(workspaceDir);
 
-        if( activeProfile.length() )
-        {
-            Utils::FilePath configPath = getCatkinToolsProfileConfigFile(workspaceDir, activeProfile);
+        if (activeProfile.length()) {
+            Utils::FilePath configPath = getCatkinToolsProfileConfigFile(workspaceDir,
+                                                                         activeProfile);
             if (!isCatkinToolsProfileConfigValid(configPath))
-              createCatkinToolsProfile(workspaceDir, activeProfile, true);
+                createCatkinToolsProfile(workspaceDir, activeProfile, true);
 
             config = YAML::LoadFile(configPath.toString().toStdString());
-            space.sourcePath = Utils::FilePath(workspaceDir).pathAppended(QString::fromStdString(config["source_space"].as<std::string>()));
-            space.buildPath = Utils::FilePath(workspaceDir).pathAppended(QString::fromStdString(config["build_space"].as<std::string>()));
-            space.develPath = Utils::FilePath(workspaceDir).pathAppended(QString::fromStdString(config["devel_space"].as<std::string>()));
-            space.installPath = Utils::FilePath(workspaceDir).pathAppended(QString::fromStdString(config["install_space"].as<std::string>()));
-            space.logPath = Utils::FilePath(workspaceDir).pathAppended(QString::fromStdString(config["log_space"].as<std::string>()));
+            space.sourcePath = Utils::FilePath(workspaceDir)
+                                   .pathAppended(QString::fromStdString(
+                                       config["source_space"].as<std::string>()));
+            space.buildPath = Utils::FilePath(workspaceDir)
+                                  .pathAppended(QString::fromStdString(
+                                      config["build_space"].as<std::string>()));
+            space.develPath = Utils::FilePath(workspaceDir)
+                                  .pathAppended(QString::fromStdString(
+                                      config["devel_space"].as<std::string>()));
+            space.installPath = Utils::FilePath(workspaceDir)
+                                    .pathAppended(QString::fromStdString(
+                                        config["install_space"].as<std::string>()));
+            space.logPath = Utils::FilePath(workspaceDir)
+                                .pathAppended(
+                                    QString::fromStdString(config["log_space"].as<std::string>()));
             space.install = config["install"].as<bool>();
-        }
-        else
-        {
+        } else {
             // TODO: This is temporary fix since at time of CatkinTools.workspace creation
             // <Directory>.</Directory> is created instead of <Directory>src</Directory>
             // which causes random crash in file watcher reading "." instead of "src"
-            space.sourcePath = Utils::FilePath(workspaceDir).pathAppended(QString::fromStdString("src"));
+            space.sourcePath = Utils::FilePath(workspaceDir)
+                                   .pathAppended(QString::fromStdString("src"));
         }
         break;
     }
-    case Colcon:
-    {
+    case Colcon: {
         space.sourcePath = Utils::FilePath(workspaceDir).pathAppended("src");
         space.buildPath = Utils::FilePath(workspaceDir).pathAppended("build");
-        space.develPath = Utils::FilePath(workspaceDir).pathAppended("install"); // Colcon does not have devel space setting to install
+        space.develPath = Utils::FilePath(workspaceDir)
+                              .pathAppended(
+                                  "install"); // Colcon does not have devel space setting to install
         space.installPath = Utils::FilePath(workspaceDir).pathAppended("install");
         space.logPath = Utils::FilePath(workspaceDir).pathAppended("log");
         space.install = true; // Calcon always uses the install space.
@@ -1216,7 +1225,8 @@ ROSUtils::WorkspaceInfo ROSUtils::getWorkspaceInfo(const Utils::FilePath &worksp
     return space;
 }
 
-QProcessEnvironment ROSUtils::getWorkspaceEnvironment(const WorkspaceInfo &workspaceInfo, const Utils::Environment& current_environment)
+QProcessEnvironment ROSUtils::getWorkspaceEnvironment(const WorkspaceInfo &workspaceInfo,
+                                                      const Utils::Environment &current_environment)
 {
     QProcess process;
 
@@ -1231,24 +1241,23 @@ QProcessEnvironment ROSUtils::getWorkspaceEnvironment(const WorkspaceInfo &works
     return env;
 }
 
-bool ROSUtils::findPackageBuildDirectory(const WorkspaceInfo &workspaceInfo, const PackageInfo &packageInfo, Utils::FilePath &packageBuildPath)
+bool ROSUtils::findPackageBuildDirectory(const WorkspaceInfo &workspaceInfo,
+                                         const PackageInfo &packageInfo,
+                                         Utils::FilePath &packageBuildPath)
 {
     packageBuildPath = workspaceInfo.buildPath;
-    switch(workspaceInfo.buildSystem) {
-    case CatkinMake:
-    {
+    switch (workspaceInfo.buildSystem) {
+    case CatkinMake: {
         QString diff = packageInfo.path.toString();
         diff.remove(workspaceInfo.sourcePath.toString());
         packageBuildPath = packageBuildPath.stringAppended(diff);
         break;
     }
-    case CatkinTools:
-    {
+    case CatkinTools: {
         packageBuildPath = workspaceInfo.buildPath.pathAppended(packageInfo.name);
         break;
     }
-    case Colcon:
-    {
+    case Colcon: {
         packageBuildPath = workspaceInfo.buildPath.pathAppended(packageInfo.name);
         break;
     }

--- a/src/project_manager/ros_utils.h
+++ b/src/project_manager/ros_utils.h
@@ -21,18 +21,19 @@
 #ifndef ROSUTILS_H
 #define ROSUTILS_H
 
+#include "ros_project_constants.h"
+#include <utils/environment.h>
+#include <utils/fileutils.h>
 #include <QProcess>
 #include <QProcessEnvironment>
-#include <QXmlStreamWriter>
 #include <QRegularExpression>
-#include <utils/fileutils.h>
-#include <utils/environment.h>
-#include "ros_project_constants.h"
+#include <QXmlStreamWriter>
 
 namespace ROSProjectManager {
 namespace Internal {
 
-class ROSUtils {
+class ROSUtils
+{
 public:
     ROSUtils();
 
@@ -54,33 +55,33 @@ public:
     };
 
     /** @brief The FolderContent struct used to store file and folder information */
-    struct FolderContent {
+    struct FolderContent
+    {
         QStringList files;       /**< @brief Directory Files */
         QStringList directories; /**< @brief Directory Subdirectories */
 
         void removeDirectories(const QStringList &filters)
         {
-            for (const QString& filter : filters)
-            {
+            for (const QString &filter : filters) {
                 QStringList remove_dirs = directories.filter(QRegularExpression(filter));
-                for (auto& d : remove_dirs)
+                for (auto &d : remove_dirs)
                     directories.removeAll(d);
             }
         }
 
         void removeFiles(const QStringList &filters)
         {
-            for (const QString& filter : filters)
-            {
+            for (const QString &filter : filters) {
                 QStringList remove_files = files.filter(QRegularExpression(filter));
-                for (auto& f : remove_files)
+                for (auto &f : remove_files)
                     files.removeAll(f);
             }
         }
     };
 
     /** @brief Contains relavent workspace information */
-    struct WorkspaceInfo {
+    struct WorkspaceInfo
+    {
         Utils::FilePath path;
         Utils::FilePath sourcePath;
         Utils::FilePath buildPath;
@@ -93,7 +94,8 @@ public:
         BuildSystem buildSystem;
     };
 
-    struct PackageTargetInfo {
+    struct PackageTargetInfo
+    {
         QString name;              /**< @brief Target name */
         TargetType type;           /**< @brief Target type */
         Utils::FilePath flagsFile; /**< @brief Path to the Target's flags.cmake file */
@@ -105,10 +107,11 @@ public:
     typedef QList<PackageTargetInfo> PackageTargetInfoList;
 
     /** @brief Contains all relavent package information */
-    struct PackageInfo {
-        Utils::FilePath path;           /**< @brief Package directory path */
-        Utils::FilePath filepath;       /**< @brief Package package.xml filepath */
-        Utils::FilePath buildFile;      /**< @brief Package CMakeLists.txt filepath */
+    struct PackageInfo
+    {
+        Utils::FilePath path;      /**< @brief Package directory path */
+        Utils::FilePath filepath;  /**< @brief Package package.xml filepath */
+        Utils::FilePath buildFile; /**< @brief Package CMakeLists.txt filepath */
 
         QString name;                   /**< @brief Package Name */
         QString version;                /**< @brief Package Version */
@@ -124,7 +127,9 @@ public:
         bool metapackage;               /**< @brief Package is a metapackage if true */
 
         // Constructor
-        PackageInfo() : metapackage(false) {}
+        PackageInfo()
+            : metapackage(false)
+        {}
 
         /**
          * @brief Check if package exists.
@@ -134,11 +139,9 @@ public:
     };
 
     /** @brief Contains a packages relavent build informations */
-    struct PackageBuildInfo {
-        PackageBuildInfo(const PackageInfo packageInfo)
-        {
-            parent = packageInfo;
-        }
+    struct PackageBuildInfo
+    {
+        PackageBuildInfo(const PackageInfo packageInfo) { parent = packageInfo; }
 
         Utils::FilePath path;          /**< @brief Path to the Package's build directory */
         Utils::FilePath cbpFile;       /**< @brief Path to the Package's CodeBlocks file */
@@ -156,8 +159,9 @@ public:
     typedef QMap<QString, PackageInfo> PackageInfoMap;
 
     /** @brief Contains project file information */
-    struct ROSProjectFileContent {
-        Utils::FilePath distribution;                     /**< @brief ROS Distribution */
+    struct ROSProjectFileContent
+    {
+        Utils::FilePath distribution;             /**< @brief ROS Distribution */
         ROSUtils::BuildSystem defaultBuildSystem; /**< @brief Default build system */
         QStringList watchDirectories;             /**< @brief Watch directories */
     };
@@ -183,8 +187,7 @@ public:
      * @param workspaceInfo Workspace information
      * @return True if successful
      */
-    static bool sourceWorkspace(QProcess *process,
-                                const WorkspaceInfo &workspaceInfo);
+    static bool sourceWorkspace(QProcess *process, const WorkspaceInfo &workspaceInfo);
 
     /**
      * @brief Check whether the provided workspace has been initialized
@@ -199,8 +202,7 @@ public:
      * @param workspaceInfo Workspace information
      * @return True if successfully executed, otherwise false
      */
-    static bool initializeWorkspace(QProcess *process,
-                                    const WorkspaceInfo &workspaceInfo);
+    static bool initializeWorkspace(QProcess *process, const WorkspaceInfo &workspaceInfo);
 
     /**
      * @brief Initialize workspace folders
@@ -215,8 +217,7 @@ public:
      * @param workspaceInfo Workspace information
      * @return True if successfully executed, otherwise false
      */
-    static bool buildWorkspace(QProcess *process,
-                               const WorkspaceInfo &workspaceInfo);
+    static bool buildWorkspace(QProcess *process, const WorkspaceInfo &workspaceInfo);
 
     /**
      * @brief Gets a list of installed ROS Distributions
@@ -241,15 +242,13 @@ public:
     static bool parseQtCreatorWorkspaceFile(const Utils::FilePath &filePath,
                                             ROSProjectFileContent &content);
 
-
     /**
      * @brief Get the default folder content filters used when building the project tree
      * @param folderNameFilters Return the default folder to be filtered
      * @param fileNameFilters Return the default files to be filtered
      */
-    static void getDefaultFolderContentFilters(QStringList& folderNameFilters,
-                                               QStringList& fileNameFilters);
-
+    static void getDefaultFolderContentFilters(QStringList &folderNameFilters,
+                                               QStringList &fileNameFilters);
 
     /**
      * @brief Get folder content for a given folder
@@ -257,8 +256,8 @@ public:
      * @return FolderContent FolderContent
      */
     static FolderContent getFolderContent(const QString &folderPath,
-                                          const QStringList& folderNameFilters,
-                                          const QStringList& fileNameFilters);
+                                          const QStringList &folderNameFilters,
+                                          const QStringList &fileNameFilters);
 
     /**
      * @brief Gets all fo the files in a given folder
@@ -298,9 +297,10 @@ public:
      * @param cachedPackageBuildInfo Cached Package build information if it fails
      * @return PackageBuildInfo
      */
-    static PackageBuildInfoMap getWorkspacePackageBuildInfo(const WorkspaceInfo &workspaceInfo,
-                                                            const PackageInfoMap &packageInfo,
-                                                            const PackageBuildInfoMap *cachedPackageBuildInfo = NULL);
+    static PackageBuildInfoMap getWorkspacePackageBuildInfo(
+        const WorkspaceInfo &workspaceInfo,
+        const PackageInfoMap &packageInfo,
+        const PackageBuildInfoMap *cachedPackageBuildInfo = NULL);
 
     /**
      * @brief Executes the bash command "rospack list" and returns a map of QMap(Package Name, Path
@@ -330,7 +330,8 @@ public:
      * @param env ROS Workspace Environment
      * @return QStringList of executables
      */
-    static QMap<QString, QString> getROSPackageExecutables(const QString &packageName, const QStringList &env);
+    static QMap<QString, QString> getROSPackageExecutables(const QString &packageName,
+                                                           const QStringList &env);
 
     /**
      * @brief Remove catkin tools profile
@@ -426,7 +427,8 @@ public:
      * @param rosDistribution ROS distribution (Hydro, Indigo, etc.)
      * @return QProcessEnvironment
      */
-    static QProcessEnvironment getWorkspaceEnvironment(const WorkspaceInfo &workspaceInfo, const Utils::Environment &current_environment);
+    static QProcessEnvironment getWorkspaceEnvironment(
+        const WorkspaceInfo &workspaceInfo, const Utils::Environment &current_environment);
 
 private:
     /**
@@ -444,8 +446,7 @@ private:
      * @param package Package Info Objects
      * @return True if successful, otherwise false.
      */
-    static bool parseCodeBlocksFile(const WorkspaceInfo &workspaceInfo,
-                                    PackageBuildInfo &package);
+    static bool parseCodeBlocksFile(const WorkspaceInfo &workspaceInfo, PackageBuildInfo &package);
 
     /**
      * @brief Get path to the profiles directory
@@ -496,7 +497,7 @@ private:
      * @param configPath Path to profiles config.yaml file
      * @return False if the file does not exist or if the contents of the yaml file are not valid.
      */
-    static bool isCatkinToolsProfileConfigValid(const Utils::FilePath& configPath);
+    static bool isCatkinToolsProfileConfigValid(const Utils::FilePath &configPath);
 
     /**
      * @brief Find a given packages build directory


### PR DESCRIPTION
This adapts the code style to the one used by Qt Creator using clang-format with the style file from the upstream project: https://code.qt.io/cgit/qt-creator/qt-creator.git/tree/.clang-format.

Since this PR touches every file, I would hold off the merge until we know that this style file is the correct one that we need to get the plugin merged upstream.

Edit: I added a script that applies the style to all source and header files. It has to be called from the source root. Note that different clang-format versions can result in different results. This is with clang-format 10.