### PR TITLE
remove WatchDirectories from workspace file

### DIFF
--- a/src/project_manager/ros_project.h
+++ b/src/project_manager/ros_project.h
@@ -121,7 +121,7 @@ private:
     QFutureWatcher<CppToolsFutureResults> m_futureBuildCodeModelWatcher;
 
     static void buildProjectTree(const Utils::FilePath projectFilePath,
-                                 const QStringList watchDirectories,
+                                 const Utils::FilePath& sourcePath,
                                  QFutureInterface<FutureWatcherResults> &fi);
 
     static void buildCppCodeModel(const ROSUtils::WorkspaceInfo workspaceInfo,

--- a/src/project_manager/ros_project_wizard.cpp
+++ b/src/project_manager/ros_project_wizard.cpp
@@ -264,7 +264,6 @@ Core::GeneratedFiles ROSProjectWizard::generateFiles(const QWizard *w, QString *
     projectFileContent.distribution = wizard->distribution();
 
     ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(wizard->workspaceDirectory(), projectFileContent.defaultBuildSystem, wizard->distribution());
-    projectFileContent.watchDirectories.append(QDir(workspaceInfo.sourcePath.toString()).dirName());
 
     Core::GeneratedFile generatedWorkspaceFile(workspaceFileName);
     QString content;

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -348,12 +348,6 @@ bool ROSUtils::generateQtCreatorWorkspaceFile(QXmlStreamWriter &xmlFile, const R
     xmlFile.writeAttribute(QLatin1String("value"), QString::number(content.defaultBuildSystem));
     xmlFile.writeEndElement();
 
-    xmlFile.writeStartElement(QLatin1String("WatchDirectories"));
-    for (const QString& str : content.watchDirectories)
-        xmlFile.writeTextElement(QLatin1String("Directory"), str);
-
-    xmlFile.writeEndElement();
-
     xmlFile.writeEndElement();
     xmlFile.writeEndDocument();
     return xmlFile.hasError();
@@ -365,8 +359,6 @@ bool ROSUtils::parseQtCreatorWorkspaceFile(const Utils::FilePath &filePath, ROSP
     QFile workspaceFile(filePath.toString());
     if (workspaceFile.open(QFile::ReadOnly | QFile::Text))
     {
-        content.watchDirectories.clear();
-
         workspaceXml.setDevice(&workspaceFile);
         while(workspaceXml.readNextStartElement())
         {
@@ -413,17 +405,7 @@ bool ROSUtils::parseQtCreatorWorkspaceFile(const Utils::FilePath &filePath, ROSP
 
                 workspaceXml.readNextStartElement();
             }
-            else if (workspaceXml.name() == QLatin1String("WatchDirectories"))
-            {
-                while(workspaceXml.readNextStartElement())
-                    if(workspaceXml.name() == QLatin1String("Directory"))
-                        content.watchDirectories.append(workspaceXml.readElementText());
-            }
         }
-
-        // If there is not a directory tag it will watch the workspace directory.
-        if (content.watchDirectories.size() == 0)
-            content.watchDirectories.append("");
 
         return true;
     }

--- a/src/project_manager/ros_utils.h
+++ b/src/project_manager/ros_utils.h
@@ -159,7 +159,6 @@ public:
     struct ROSProjectFileContent {
         Utils::FilePath distribution;             /**< @brief ROS Distribution */
         ROSUtils::BuildSystem defaultBuildSystem; /**< @brief Default build system */
-        QStringList watchDirectories;             /**< @brief Watch directories */
     };
 
     /**


### PR DESCRIPTION
The entry was redundant.
It always contained exactly one entry which is the sourcePath of the workspace.
This should be queried at runtime though instead of being read from the workspace file.

New projects will not have the entry anymore, old projects will ignore it.

Implemented as per https://github.com/ros-industrial/ros_qtc_plugin/issues/425#issuecomment-771565005

Fixes #425 