### PR TITLE
CI build and release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,134 @@
+name: ROS Qt Creator plugin build and archive release
+
+on: [push]
+
+jobs:
+  build:
+    name: build (${{ matrix.config.name }})
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - { name: "Linux", os: ubuntu-latest }
+          # - { name: "Windows", os: windows-latest }
+          - { name: "macOS", os: macos-latest }
+    outputs:
+      archive_name: ${{ steps.find_plugin_archive.outputs.archive_name }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+
+      - uses: conda-incubator/setup-miniconda@v2
+        if: runner.os == 'Windows'
+
+      - name: install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install libgl1-mesa-dev ninja-build libyaml-cpp-dev libqtermwidget5-0-dev libutf8proc-dev
+
+      - name: install Windows system dependencies
+        if: runner.os == 'Windows'
+        run: |
+          choco install ninja
+          conda install -c conda-forge yaml-cpp
+
+      - name: install macOS system dependencies
+        if: runner.os == 'macOS'
+        run: brew install ninja yaml-cpp
+
+      - name: install Qt and Qt Creator
+        shell: bash
+        run: |
+          pip install pyyaml requests py7zr
+          python setup.py --export_variables
+          cat env >> $GITHUB_ENV
+
+      - name: install qtermwidget
+        if: runner.os != 'Linux'
+        shell: bash
+        run: |
+          git clone https://github.com/lxqt/lxqt-build-tools.git extern/lxqt-build-tools
+          cd extern/lxqt-build-tools
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.QTC_PREFIX_PATH }}
+          cmake --build build --target install
+          cd ../..
+          git clone https://github.com/lxqt/qtermwidget.git extern/qtermwidget
+          cd extern/qtermwidget
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.QTC_PREFIX_PATH }}
+          cmake --build build --target install
+
+      - name: build plugin
+        run: |
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.QTC_PREFIX_PATH }}
+          cmake --build build --target package
+
+      - name: find plugin archive
+        id: find_plugin_archive
+        shell: bash
+        run: |
+          find build/ -maxdepth 1 -name 'ROSProjectManager-*-*-*.zip' -print0 | xargs -0 basename -a > ./archive_name
+          echo "QTC_PLUGIN_ARCHIVE=`cat ./archive_name`" >> $GITHUB_ENV
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: plugin_archive_artifact_${{ matrix.config.name }}
+          if-no-files-found: error
+          path: |
+            ./build/${{ env.QTC_PLUGIN_ARCHIVE }}
+            ./archive_name
+
+  release:
+    name: create release
+    if: contains(github.ref, '/tags/')
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: create release
+        uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+  publish:
+    name: publish plugin archive (${{ matrix.name }})
+    if: contains(github.ref, '/tags/')
+    runs-on: ubuntu-latest
+    needs: [build, release]
+    strategy:
+      matrix:
+        name:
+          - Linux
+          # - Windows
+          - macOS
+    steps:
+      - name: download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: plugin_archive_artifact_${{ matrix.name }}
+          path: ./
+
+      - name: set archive name
+        shell: bash
+        run: echo "QTC_PLUGIN_ARCHIVE=`cat ./archive_name`" >> $GITHUB_ENV
+
+      - name: upload archive release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{needs.release.outputs.upload_url}}
+          asset_path: ./build/${{ env.QTC_PLUGIN_ARCHIVE }}
+          asset_name: ${{ env.QTC_PLUGIN_ARCHIVE }}
+          asset_content_type: application/zip

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,4 +2,4 @@ qtc_version: "5.0"
 qtc_modules: ["qtcreator", "qtcreator_dev"]
 
 qt_version: "5.15"
-qt_modules: ['qtbase', 'qtdeclarative', 'icu']
+qt_modules: ['qtbase', 'qtdeclarative', 'icu', 'qttools']


### PR DESCRIPTION
This adds a GitHub workflow to build the Qt Creator plugin and release the plugin archive as an asset for every tagged release. The workflow depends on the CMake build script and the `setup.py` script that fetches the Qt Creator dependencies. Hence,  PR #434 is included with this PR and should be reviewed/merged first.

The workflow will upload the plugin archive to the release page automatically once a git tag was pushed. For new releases, we then only have to adapt the API to the new Qt Creator version, set the new version in `versions.yaml` for the script and push a new tag.

You can see at https://github.com/christian-rauch/ros_qtc_plugin/releases/tag/test_rel_2 how this would look like. The release page will initially only show the last commit message as information. So the last commit of a release could pumb the versions in the CMake and `versions.yaml` and add some information, or this information can also be changed later. Since the archvie is formatted only with the version of the plugin (e.g. `ROSProjectManager-0.3.11-Linux-x86_64.zip`), not the Qt Creator version, it's probably a good idea to increment the plugin version anyway to prevent filename clashes.