### PR TITLE
installation instructions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: ROS Qt Creator plugin build and archive release
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.10)
 
 project(ROSProjectManager VERSION 0.4.0)
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    add_link_options("-Wl,-z,relro,-z,now,-z,defs")
+endif()
+
 add_subdirectory(src/project_manager)
 
 # generate plugin archive

--- a/README.md
+++ b/README.md
@@ -64,3 +64,21 @@ Finally, compile the plugin and create an archive:
 cmake --build build --target package
 ```
 This will create an archive of the format `ROSProjectManager-${version}-Linux-${arch}.zip` inside the build folder (`build` by default). This archive can either be imported by Qt Creator via Help → About Plugins… → Install Plugin… or alternatively extracted directly to `~/Qt/Tools/QtCreator/`.
+
+## Installation
+
+Install the runtime dependencies `yaml-cpp` and `qtermwidget` via apt:
+```bash
+sudo apt install '^(libyaml-cpp|libqtermwidget).*([^v]|[^e]v|[^d]ev|[^-]dev)$'
+```
+
+Download the plugin archive from the [release page](https://github.com/ros-industrial/ros_qtc_plugin/releases/latest) and extract it into the root of a Qt Creator installation. Qt Creator can be installed via the official [online](https://www.qt.io/download-thank-you) and [offline](https://www.qt.io/offline-installers) installer. The Qt Creator root will be `~/Qt/Tools/QtCreator` for the online installer and `~/qtcreator-${version}` for the offline installer. The following script extracts the archive to the default online installer location:
+```bash
+sudo apt install libarchive-tools # needed for bsdtar
+export QTC_ROOT=~/Qt/Tools/QtCreator # online installer
+# export QTC_ROOT=~/qtcreator-5.0.0 # offline installer
+export PLUGIN_URL=`curl -s https://api.github.com/repos/ros-industrial/ros_qtc_plugin/releases/latest | grep -E 'browser_download_url.*ROSProjectManager-.*-Linux-.*.zip' | cut -d'"' -f 4`
+curl -SL $PLUGIN_URL | bsdtar -xzf - -C $QTC_ROOT
+```
+
+Note: Qt Creator from the online installer may notify you about available updates and install them when instructed to do so. The plugin API is only compatible with patch updates. A major or minor update will break the plugin API and Qt Creator will then refuse to load the plugin. Make sure that a compatible plugin version is available before updating Qt Creator, since it is not possible to downgrade to an older Qt Creator version using the online installer. The offline installer installs a specific Qt Creator version and does not provide updates.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Additionally, you need:
 - utf8proc
 
 The can be installed via apt on Ubuntu:
-```
+```bash
 sudo apt install libgl1-mesa-dev ninja-build libyaml-cpp-dev libqtermwidget5-0-dev libutf8proc-dev
 ```
 
 To use the `setup.py` script, you will need additional python dependencies:
-```
+```bash
 pip install pyyaml requests py7zr
 ```
 
@@ -51,16 +51,16 @@ pip install pyyaml requests py7zr
 If Qt Creator and the Plugin Development package are not installed in one of the default folders, you have to tell CMake via `CMAKE_PREFIX_PATH` where those can be found.
 
 When using the official Qt binary installer with the default installation path, this is:
-```
+```bash
 cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="~/Qt/Tools/QtCreator/;~/Qt/5.15.2/gcc_64"
 ```
 When using the `setup.py` script, the script will show the installation path (which can be adjusted using `--install_path`) and the compile commands. On `x86_64` Linux with the default path, this is:
-```
+```bash
 cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/tmp/qtc_sdk/Tools/QtCreator;/tmp/qtc_sdk/5.15.0/gcc_64"
 ```
 
 Finally, compile the plugin and create an archive:
-```
+```bash
 cmake --build build --target package
 ```
 This will create an archive of the format `ROSProjectManager-${version}-Linux-${arch}.zip` inside the build folder (`build` by default). This archive can either be imported by Qt Creator via Help → About Plugins… → Install Plugin… or alternatively extracted directly to `~/Qt/Tools/QtCreator/`.


### PR DESCRIPTION
Document plugin installation with a bash script that downloads the latest plugin archive for Linux and extracts it to the default Qt Creator installation.