### PR TITLE
fix package wizard

### DIFF
--- a/src/project_manager/ros_build_system.cpp
+++ b/src/project_manager/ros_build_system.cpp
@@ -23,6 +23,8 @@ void ROSBuildSystem::triggerParsing()
 
 bool ROSBuildSystem::addFiles(ProjectExplorer::Node *context, const Utils::FilePaths &filePaths, Utils::FilePaths *notAdded)
 {
+    // update entire workspace project
+    dynamic_cast<ROSProject *>(context->getProject())->refresh();
     return true;
 }
 

--- a/src/project_manager/ros_build_system.cpp
+++ b/src/project_manager/ros_build_system.cpp
@@ -21,27 +21,27 @@ void ROSBuildSystem::triggerParsing()
     guardParsingRun().markAsSuccess();
 }
 
-bool ROSBuildSystem::addFiles(ProjectExplorer::Node *context, const QStringList &filePaths, QStringList *notAdded)
+bool ROSBuildSystem::addFiles(ProjectExplorer::Node *context, const Utils::FilePaths &filePaths, Utils::FilePaths *notAdded)
 {
     return true;
 }
 
-ProjectExplorer::RemovedFilesFromProject ROSBuildSystem::removeFiles(ProjectExplorer::Node *context, const QStringList &filePaths, QStringList *notRemoved)
+ProjectExplorer::RemovedFilesFromProject ROSBuildSystem::removeFiles(ProjectExplorer::Node *context, const Utils::FilePaths &filePaths, Utils::FilePaths *notRemoved)
 {
     return ProjectExplorer::RemovedFilesFromProject::Ok;
 }
 
-bool ROSBuildSystem::deleteFiles(ProjectExplorer::Node *context, const QStringList &filePaths)
+bool ROSBuildSystem::deleteFiles(ProjectExplorer::Node *context, const Utils::FilePaths &filePaths)
 {
     return true;
 }
 
-bool ROSBuildSystem::canRenameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath)
+bool ROSBuildSystem::canRenameFile(ProjectExplorer::Node *context, const Utils::FilePath &oldFilePath, const Utils::FilePath &newFilePath)
 {
     return true;
 }
 
-bool ROSBuildSystem::renameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath)
+bool ROSBuildSystem::renameFile(ProjectExplorer::Node *context, const Utils::FilePath &oldFilePath, const Utils::FilePath &newFilePath)
 {
     return true;
 }

--- a/src/project_manager/ros_build_system.h
+++ b/src/project_manager/ros_build_system.h
@@ -21,14 +21,13 @@ public:
 
     void triggerParsing() final;
 
-    virtual bool addFiles(ProjectExplorer::Node *context, const QStringList &filePaths, QStringList *notAdded = nullptr) final;
-    virtual ProjectExplorer::RemovedFilesFromProject removeFiles(ProjectExplorer::Node *context, const QStringList &filePaths,
-                                                                 QStringList *notRemoved = nullptr) final;
-    virtual bool deleteFiles(ProjectExplorer::Node *context, const QStringList &filePaths) final;
-    virtual bool canRenameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath) final;
-    virtual bool renameFile(ProjectExplorer::Node *context, const QString &filePath, const QString &newFilePath) final;
-    virtual bool addDependencies(ProjectExplorer::Node *context, const QStringList &dependencies) final;
-    virtual bool supportsAction(ProjectExplorer::Node *context, ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const final;
+    virtual bool addFiles(ProjectExplorer::Node *context, const Utils::FilePaths &filePaths, Utils::FilePaths *notAdded = nullptr) override final;
+    virtual ProjectExplorer::RemovedFilesFromProject removeFiles(ProjectExplorer::Node *context, const Utils::FilePaths &filePaths, Utils::FilePaths *notRemoved = nullptr) override final;
+    virtual bool deleteFiles(ProjectExplorer::Node *context, const Utils::FilePaths &filePaths) override final;
+    virtual bool canRenameFile(ProjectExplorer::Node *context, const Utils::FilePath &oldFilePath, const Utils::FilePath &newFilePath) override final;
+    virtual bool renameFile(ProjectExplorer::Node *context, const Utils::FilePath &oldFilePath, const Utils::FilePath &newFilePath) override final;
+    virtual bool addDependencies(ProjectExplorer::Node *context, const QStringList &dependencies) override final;
+    virtual bool supportsAction(ProjectExplorer::Node *context, ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const override final;
 };
 
 } // namespace Internal

--- a/src/project_manager/ros_package_wizard.cpp
+++ b/src/project_manager/ros_package_wizard.cpp
@@ -343,8 +343,11 @@ bool ROSPackageWizard::writeFiles(const Core::GeneratedFiles &files, QString *er
   cmd += QString::fromLatin1(" --rosdistro \"%1\"").arg(project->distribution().fileName());
 
   // create package using ros command catkin_create_pkg
-  Utils::FilePath packagePath = Utils::FilePath::fromString(m_wizard->packagePath());
-  catkin_create_pkg->setWorkingDirectory(packagePath.toString());
+  const QDir packagePath = m_wizard->packagePath();
+  if (!packagePath.exists()) {
+      packagePath.mkpath(".");
+  }
+  catkin_create_pkg->setWorkingDirectory(packagePath.path());
 
   ROSUtils::sourceROS(catkin_create_pkg, project->distribution());
   catkin_create_pkg->start(QLatin1String("bash"), QStringList() << QLatin1String("-c") << cmd);

--- a/src/project_manager/ros_package_wizard.h
+++ b/src/project_manager/ros_package_wizard.h
@@ -53,8 +53,6 @@ public:
     QString version() const;
     QString licenses() const;
     QString description() const;
-    QStringList authors() const;
-    QStringList maintainers() const;
     QStringList catkin_dependencies() const;
     QStringList system_dependencies() const;
     QStringList boost_components() const;
@@ -81,8 +79,6 @@ public:
     QString version() const;
     QString licenses() const;
     QString description() const;
-    QStringList authors() const;
-    QStringList maintainers() const;
     QStringList catkin_dependencies() const;
     QStringList system_dependencies() const;
     QStringList boost_components() const;

--- a/src/project_manager/ros_package_wizard_details_page.ui
+++ b/src/project_manager/ros_package_wizard_details_page.ui
@@ -88,119 +88,6 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="authorsLabel">
-     <property name="text">
-      <string>Authors:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="maintainerLabel">
-     <property name="text">
-      <string>Maintainers:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="descriptionLabel">
-     <property name="text">
-      <string>Description:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="1">
-    <widget class="QPlainTextEdit" name="descriptionPlainTextEdit"/>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="dependsLabel">
-     <property name="text">
-      <string>Dependencies</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QLineEdit" name="maintainersLineEdit"/>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="catkinLabel">
-     <property name="minimumSize">
-      <size>
-       <width>101</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Catkin:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <property name="indent">
-      <number>40</number>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="systemLabel">
-     <property name="minimumSize">
-      <size>
-       <width>101</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>System:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <property name="indent">
-      <number>40</number>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="boostLabel">
-     <property name="text">
-      <string>Boost:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <property name="margin">
-      <number>0</number>
-     </property>
-     <property name="indent">
-      <number>40</number>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QLineEdit" name="authorsLineEdit">
-     <property name="inputMethodHints">
-      <set>Qt::ImhNone</set>
-     </property>
-     <property name="inputMask">
-      <string/>
-     </property>
-     <property name="frame">
-      <bool>true</bool>
-     </property>
-     <property name="echoMode">
-      <enum>QLineEdit::Normal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QLineEdit" name="catkinLineEdit"/>
-   </item>
-   <item row="9" column="1">
-    <widget class="QLineEdit" name="systemLineEdit"/>
-   </item>
-   <item row="10" column="1">
-    <widget class="QLineEdit" name="boostLineEdit"/>
-   </item>
    <item row="3" column="1">
     <widget class="QComboBox" name="licenseComboBox">
      <property name="editable">
@@ -253,6 +140,86 @@
      </item>
     </widget>
    </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="dependsLabel">
+     <property name="text">
+      <string>Dependencies</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="catkinLabel">
+     <property name="minimumSize">
+      <size>
+       <width>101</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Catkin:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="indent">
+      <number>40</number>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLineEdit" name="catkinLineEdit"/>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="systemLabel">
+     <property name="minimumSize">
+      <size>
+       <width>101</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>System:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="indent">
+      <number>40</number>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="systemLineEdit"/>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="boostLabel">
+     <property name="text">
+      <string>Boost:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="margin">
+      <number>0</number>
+     </property>
+     <property name="indent">
+      <number>40</number>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QLineEdit" name="boostLineEdit"/>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="descriptionLabel">
+     <property name="text">
+      <string>Description:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QPlainTextEdit" name="descriptionPlainTextEdit"/>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -272,8 +239,6 @@
   <tabstop>packageNameLineEdit</tabstop>
   <tabstop>versionLineEdit</tabstop>
   <tabstop>licenseComboBox</tabstop>
-  <tabstop>authorsLineEdit</tabstop>
-  <tabstop>maintainersLineEdit</tabstop>
   <tabstop>catkinLineEdit</tabstop>
   <tabstop>systemLineEdit</tabstop>
   <tabstop>boostLineEdit</tabstop>

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -271,7 +271,7 @@ QList<Utils::FilePath> ROSUtils::installedDistributions()
     QDir custom_dir(custom_ros_path.toString());
 
     custom_dir.setFilter(QDir::NoDotAndDotDot | QDir::Dirs);
-    for (auto entry : custom_dir.entryList())
+    for (const auto &entry : custom_dir.entryList())
     {
       Utils::FilePath path(custom_ros_path);
       path = path.pathAppended(entry);
@@ -291,7 +291,7 @@ QList<Utils::FilePath> ROSUtils::installedDistributions()
     QDir ros_opt(default_ros_path.toString());
 
     ros_opt.setFilter(QDir::NoDotAndDotDot | QDir::Dirs);
-    for (auto entry : ros_opt.entryList())
+    for (const auto &entry : ros_opt.entryList())
     {
       Utils::FilePath path = Utils::FilePath::fromString(QLatin1String(ROSProjectManager::Constants::ROS_INSTALL_DIRECTORY));
       path = path.pathAppended(entry);
@@ -444,7 +444,7 @@ QHash<QString, ROSUtils::FolderContent> ROSUtils::getFolderContentRecursive(cons
     QStringList folderNameFilters, fileNameFilters;
     getDefaultFolderContentFilters(folderNameFilters, fileNameFilters);
 
-    ROSUtils::FolderContent content = getFolderContent(folder, folderNameFilters, fileNameFilters);
+    const ROSUtils::FolderContent content = getFolderContent(folder, folderNameFilters, fileNameFilters);
 
     workspaceFiles[folder] = content;
 
@@ -464,7 +464,7 @@ QHash<QString, ROSUtils::FolderContent> ROSUtils::getFolderContentRecursive(cons
 
         QString folder_name = Utils::FilePath::fromString(folder).fileName();
         bool found = false;
-        for (auto filter : folderNameFilters)
+        for (const auto& filter : qAsConst(folderNameFilters))
         {
           QRegularExpression rx(filter);
           if (rx.match(folder_name).hasMatch())
@@ -490,7 +490,7 @@ QHash<QString, ROSUtils::FolderContent> ROSUtils::getFolderContentRecursive(cons
 
         if (skip) continue;
 
-        content = getFolderContent(folder, folderNameFilters, fileNameFilters);
+        const ROSUtils::FolderContent content = getFolderContent(folder, folderNameFilters, fileNameFilters);
 
         workspaceFiles[folder] = content;
 


### PR DESCRIPTION
This fixes a bunch of issues with the "package wizard" that creates new catkin or colcon packages (fixes !443).

`ROSPackageWizard::writeFiles` was extended so that it uses a build system (catkin, colcon) specific command to create new packages. This makes this more future proof when only ROS2 is installed. This also fixes some earlier API breakage that went silent due to missing `override` specifiers. The original problem !443 was caused by a change of the signature of virtual `ProjectExplorer::BuildSystem` methods changed. Hence, the derived `ROSBuildSystem` was not implementing methods such as `addFiles` anymore, leading into calling the base class which does not implement those functions and always returns false.