### PR TITLE
add the build tool configuration widget

### DIFF
--- a/src/project_manager/ros_catkin_make_step.cpp
+++ b/src/project_manager/ros_catkin_make_step.cpp
@@ -158,6 +158,11 @@ bool ROSCatkinMakeStep::fromMap(const QVariantMap &map)
     return BuildStep::fromMap(map);
 }
 
+QWidget *ROSCatkinMakeStep::createConfigWidget()
+{
+    return new ROSCatkinMakeStepWidget(this);
+}
+
 QString ROSCatkinMakeStep::allArguments(ROSUtils::BuildType buildType, bool includeDefault) const
 {
     QStringList args;

--- a/src/project_manager/ros_catkin_make_step.h
+++ b/src/project_manager/ros_catkin_make_step.h
@@ -65,6 +65,7 @@ public:
 protected:
     QStringList automaticallyAddedArguments() const;
     bool fromMap(const QVariantMap &map) override;
+    QWidget *createConfigWidget() override;
 
 private:
     ROSBuildConfiguration *targetsActiveBuildConfiguration() const;

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -464,6 +464,7 @@ void ROSCatkinToolsStepWidget::editProfile(const QString profileName)
     Utils::FilePath profile = ROSUtils::getCatkinToolsProfile(m_makeStep->rosBuildConfiguration()->project()->projectDirectory(), profileName);
 
     ROSCatkinToolsProfileEditorDialog *editor = new ROSCatkinToolsProfileEditorDialog(profile);
+    editor->setModal(true);
     editor->show();
 }
 

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -179,6 +179,11 @@ bool ROSCatkinToolsStep::fromMap(const QVariantMap &map)
     return BuildStep::fromMap(map);
 }
 
+QWidget *ROSCatkinToolsStep::createConfigWidget()
+{
+    return new ROSCatkinToolsStepWidget(this);
+}
+
 QString ROSCatkinToolsStep::allArguments(ROSUtils::BuildType buildType, bool includeDefault) const
 {
     QStringList args;

--- a/src/project_manager/ros_catkin_tools_step.h
+++ b/src/project_manager/ros_catkin_tools_step.h
@@ -77,6 +77,7 @@ public:
 protected:
     QStringList automaticallyAddedArguments() const;
     bool fromMap(const QVariantMap &map) override;
+    QWidget *createConfigWidget() override;
 
 private:
     ROSBuildConfiguration *targetsActiveBuildConfiguration() const;

--- a/src/project_manager/ros_colcon_step.cpp
+++ b/src/project_manager/ros_colcon_step.cpp
@@ -158,6 +158,11 @@ bool ROSColconStep::fromMap(const QVariantMap &map)
     return BuildStep::fromMap(map);
 }
 
+QWidget *ROSColconStep::createConfigWidget()
+{
+    return new ROSColconStepWidget(this);
+}
+
 QString ROSColconStep::allArguments(ROSUtils::BuildType buildType, bool includeDefault) const
 {
     QStringList args;

--- a/src/project_manager/ros_colcon_step.h
+++ b/src/project_manager/ros_colcon_step.h
@@ -66,6 +66,7 @@ public:
 protected:
     QStringList automaticallyAddedArguments() const;
     bool fromMap(const QVariantMap &map) override;
+    QWidget *createConfigWidget() override;
 
 private:
     ROSBuildConfiguration *targetsActiveBuildConfiguration() const;


### PR DESCRIPTION
This adds the configuration widgets for the build tools again (fixes #444 ). They were originally removed by 59ac8cd81323c56b94e49ab88d0aa698a3d8d4ea during API adaption.