### PR TITLE
port to Qt Creator 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         config:
           - { name: "Linux", os: ubuntu-latest }
-          # - { name: "Windows", os: windows-latest }
+          - { name: "Windows", os: windows-latest }
           - { name: "macOS", os: macos-latest }
     outputs:
       archive_name: ${{ steps.find_plugin_archive.outputs.archive_name }}
@@ -22,6 +22,10 @@ jobs:
           python-version: "3.x"
 
       - uses: conda-incubator/setup-miniconda@v2
+        if: runner.os == 'Windows'
+
+      - name: install Microsoft Visual C++ (Windows)
+        uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
 
       - name: install Linux system dependencies
@@ -110,7 +114,7 @@ jobs:
       matrix:
         name:
           - Linux
-          # - Windows
+          - Windows
           - macOS
     steps:
       - name: download artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: build plugin
         run: |
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${{ env.QTC_PATH }};${{ env.QT_PATH }}"
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${{ env.QTC_PATH }};${{ env.QT_PATH }}" -DBUILD_ROSTERMINAL=OFF
           cmake --build build --target package
 
       - name: find plugin archive

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,17 +32,30 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt update
-          sudo apt install libgl1-mesa-dev ninja-build libyaml-cpp-dev libqtermwidget5-0-dev libutf8proc-dev
+          sudo apt install libgl1-mesa-dev ninja-build libqtermwidget5-0-dev libutf8proc-dev
 
       - name: install Windows system dependencies
         if: runner.os == 'Windows'
         run: |
           choco install ninja
-          conda install -c conda-forge yaml-cpp
 
       - name: install macOS system dependencies
         if: runner.os == 'macOS'
-        run: brew install ninja yaml-cpp qt5
+        run: brew install ninja qt5
+
+      - name: install yaml-cpp
+        shell: bash
+        run: |
+          git clone --depth 1 https://github.com/jbeder/yaml-cpp.git extern/yaml-cpp --branch yaml-cpp-0.7.0
+          cd extern/yaml-cpp
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DYAML_CPP_BUILD_TESTS=OFF
+          $(which sudo) cmake --build build --target install
+
+      - name: set build environment variables (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "YAML_DIR='C:/Program Files (x86)/YAML_CPP/share/cmake/yaml-cpp/'" >> $GITHUB_ENV
 
       - name: install Qt and Qt Creator
         shell: bash
@@ -67,7 +80,7 @@ jobs:
 
       - name: build plugin
         run: |
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${{ env.QTC_PATH }};${{ env.QT_PATH }}" -DBUILD_ROSTERMINAL=OFF
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${{ env.QTC_PATH }};${{ env.QT_PATH }}" -Dyaml-cpp_DIR=${{ env.YAML_DIR }} -DBUILD_ROSTERMINAL=OFF
           cmake --build build --target package
 
       - name: find plugin archive

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: build plugin
         run: |
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.QTC_PREFIX_PATH }}
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${{ env.QTC_PATH }};${{ env.QT_PATH }}"
           cmake --build build --target package
 
       - name: find plugin archive

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: install macOS system dependencies
         if: runner.os == 'macOS'
-        run: brew install ninja yaml-cpp
+        run: brew install ninja yaml-cpp qt5
 
       - name: install Qt and Qt Creator
         shell: bash
@@ -48,17 +48,17 @@ jobs:
           cat env >> $GITHUB_ENV
 
       - name: install qtermwidget
-        if: runner.os != 'Linux'
+        if: runner.os == 'macOS'
         shell: bash
         run: |
           git clone https://github.com/lxqt/lxqt-build-tools.git extern/lxqt-build-tools
           cd extern/lxqt-build-tools
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.QTC_PREFIX_PATH }}
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DQt5Core_DIR=$(brew --prefix qt5)/lib/cmake/Qt5Core
           cmake --build build --target install
           cd ../..
           git clone https://github.com/lxqt/qtermwidget.git extern/qtermwidget
           cd extern/qtermwidget
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.QTC_PREFIX_PATH }}
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DQt5Core_DIR=$(brew --prefix qt5)/lib/cmake/Qt5Core -DQt5Widgets_DIR=$(brew --prefix qt5)/lib/cmake/Qt5Widgets -DQt5LinguistTools_DIR=$(brew --prefix qt5)/lib/cmake/Qt5LinguistTools
           cmake --build build --target install
 
       - name: build plugin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(ROSProjectManager VERSION 0.4.1)
+project(ROSProjectManager VERSION 0.5.0)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     add_link_options("-Wl,-z,relro,-z,now,-z,defs")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     add_link_options("-Wl,-z,relro,-z,now,-z,defs")
 endif()
 
+option(BUILD_ROSTERMINAL "build with an integrated ROS terminal")
+
 add_subdirectory(src/project_manager)
 
 # generate plugin archive

--- a/README.md
+++ b/README.md
@@ -67,16 +67,11 @@ This will create an archive of the format `ROSProjectManager-${version}-Linux-${
 
 ## Installation
 
-Install the runtime dependencies `yaml-cpp` and `qtermwidget` via apt:
-```bash
-sudo apt install '^(libyaml-cpp|libqtermwidget).*([^v]|[^e]v|[^d]ev|[^-]dev)$'
-```
-
 Download the plugin archive from the [release page](https://github.com/ros-industrial/ros_qtc_plugin/releases/latest) and extract it into the root of a Qt Creator installation. Qt Creator can be installed via the official [online](https://www.qt.io/download-thank-you) and [offline](https://www.qt.io/offline-installers) installer. The Qt Creator root will be `~/Qt/Tools/QtCreator` for the online installer and `~/qtcreator-${version}` for the offline installer. The following script extracts the archive to the default online installer location:
 ```bash
 sudo apt install libarchive-tools # needed for bsdtar
 export QTC_ROOT=~/Qt/Tools/QtCreator # online installer
-# export QTC_ROOT=~/qtcreator-5.0.0 # offline installer
+# export QTC_ROOT=~/qtcreator-6.0.0 # offline installer
 export PLUGIN_URL=`curl -s https://api.github.com/repos/ros-industrial/ros_qtc_plugin/releases/latest | grep -E 'browser_download_url.*ROSProjectManager-.*-Linux-.*.zip' | cut -d'"' -f 4`
 curl -SL $PLUGIN_URL | bsdtar -xzf - -C $QTC_ROOT
 ```

--- a/setup.py
+++ b/setup.py
@@ -211,4 +211,5 @@ if __name__ == "__main__":
 
     if args.export_variables:
         with open("env", 'w') as f:
-            f.write("QTC_PREFIX_PATH=\"{}\"\n".format(prefix_paths))
+            f.write("QTC_PATH={}\n".format(dir_qtc))
+            f.write("QT_PATH={}\n".format(dir_qt))

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,13 @@ def qt_download_check_extract(cfg, dir_install):
 
         py7zr.SevenZipFile(io.BytesIO(content)).extractall(dir_install)
 
-    return os.path.join(dir_install, "{}.{}.0".format(ver_maj, ver_min), compiler_bits)
+    qt_path = os.path.join(dir_install, "{}.{}.0".format(ver_maj, ver_min))
+    qt_archs = os.listdir(qt_path)
+    if len(qt_archs) > 1:
+        raise RuntimeWarning(
+            "more than one architecture found in {path}, will use first: {arch}"
+            .format(path = qt_path, arch = qt_archs[0]))
+    return os.path.join(qt_path, qt_archs[0])
 
 
 if __name__ == "__main__":

--- a/src/project_manager/CMakeLists.txt
+++ b/src/project_manager/CMakeLists.txt
@@ -6,7 +6,6 @@ set(CMAKE_CXX_STANDARD 17)
 find_package(QtCreator COMPONENTS Core REQUIRED)
 find_package(QT NAMES Qt6 COMPONENTS Widgets REQUIRED)
 find_package(yaml-cpp REQUIRED)
-find_package(qtermwidget5 REQUIRED)
 
 set(SRC
   "remove_directory_dialog.cpp"
@@ -31,9 +30,11 @@ set(SRC
   "ros_run_step.cpp"
   "ros_run_steps_page.cpp"
   "ros_settings_page.cpp"
-  "ros_terminal_pane.cpp"
   "ros_utils.cpp"
 )
+if(BUILD_ROSTERMINAL)
+  list(APPEND SRC "ros_terminal_pane.cpp")
+endif()
 
 # add the resource file
 list(APPEND SRC "ros_project.qrc")
@@ -51,10 +52,15 @@ add_qtc_plugin(${PROJECT_NAME}
     QtCreator::Utils
     Qt::Widgets
     yaml-cpp
-    qtermwidget5
   SOURCES
     ${SRC}
 )
+
+if(BUILD_ROSTERMINAL)
+  find_package(qtermwidget5 REQUIRED)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC ROSTERMINAL)
+  target_link_libraries(${PROJECT_NAME} PUBLIC qtermwidget5)
+endif()
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/share/
         DESTINATION ${IDE_DATA_PATH}

--- a/src/project_manager/CMakeLists.txt
+++ b/src/project_manager/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_CXX_STANDARD 17)
 
 find_package(QtCreator COMPONENTS Core REQUIRED)
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
+find_package(QT NAMES Qt6 COMPONENTS Widgets REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(qtermwidget5 REQUIRED)
 
@@ -42,14 +42,14 @@ add_qtc_plugin(${PROJECT_NAME}
   PLUGIN_DEPENDS
     QtCreator::CMakeProjectManager
     QtCreator::Core
-    QtCreator::CppTools
+    QtCreator::CppEditor
     QtCreator::Debugger
     QtCreator::ProjectExplorer
     QtCreator::QtSupport
     QtCreator::TextEditor
   DEPENDS
     QtCreator::Utils
-    Qt${QT_VERSION_MAJOR}::Widgets
+    Qt::Widgets
     yaml-cpp
     qtermwidget5
   SOURCES

--- a/src/project_manager/remove_directory_dialog.h
+++ b/src/project_manager/remove_directory_dialog.h
@@ -31,7 +31,7 @@ namespace Ui { class RemoveDirectoryDialog;}
 /**
  * @brief This a remove directory dialog for deleting directories.
  */
-class CORE_EXPORT RemoveDirectoryDialog : public QDialog
+class RemoveDirectoryDialog : public QDialog
 {
   Q_OBJECT
 public:

--- a/src/project_manager/ros_build_configuration.cpp
+++ b/src/project_manager/ros_build_configuration.cpp
@@ -330,7 +330,6 @@ ROSBuildEnvironmentWidget::ROSBuildEnvironmentWidget(BuildConfiguration *bc)
     : NamedWidget(tr("Build Environment"))
 {
     QVBoxLayout *vbox = new QVBoxLayout(this);
-    vbox->setMargin(0);
     m_clearSystemEnvironmentCheckBox = new QCheckBox(this);
     m_clearSystemEnvironmentCheckBox->setText(tr("Clear system environment"));
 

--- a/src/project_manager/ros_build_configuration.h
+++ b/src/project_manager/ros_build_configuration.h
@@ -46,7 +46,9 @@ namespace Internal {
 
 class ROSBuildConfigurationFactory;
 class ROSBuildSettingsWidget;
+class ROSBuildSystem;
 class ROSExtraBuildInfo;
+class ROSProject;
 namespace Ui { class ROSBuildConfiguration; }
 
 class ROSBuildConfiguration : public ProjectExplorer::BuildConfiguration

--- a/src/project_manager/ros_build_system.cpp
+++ b/src/project_manager/ros_build_system.cpp
@@ -1,5 +1,4 @@
 #include "ros_build_system.h"
-#include "ros_build_configuration.h"
 
 using namespace ProjectExplorer;
 
@@ -11,7 +10,7 @@ namespace Internal {
 // --------------------------------------------------------------------
 
 ROSBuildSystem::ROSBuildSystem(ROSBuildConfiguration *bc)
-    : BuildSystem((BuildConfiguration*)bc)
+    : BuildSystem((BuildConfiguration*)bc), ros_build_system(bc->rosBuildSystem())
 {
     connect(((BuildConfiguration*)bc)->project(), &Project::activeTargetChanged, this, [this]() { triggerParsing(); });
 }
@@ -65,6 +64,20 @@ bool ROSBuildSystem::supportsAction(ProjectExplorer::Node *context, ProjectExplo
     };
 
     return possible_actions.count(action);
+}
+
+QString ROSBuildSystem::name() const
+{
+    switch (ros_build_system) {
+    case ROSUtils::BuildSystem::CatkinMake:
+        return "catkin_make";
+    case ROSUtils::BuildSystem::CatkinTools:
+        return "catkin-tools";
+    case ROSUtils::BuildSystem::Colcon:
+        return "colcon";
+    default:
+        return QString{};
+    }
 }
 
 } // namespace Internal

--- a/src/project_manager/ros_build_system.h
+++ b/src/project_manager/ros_build_system.h
@@ -2,6 +2,7 @@
 
 #include <projectexplorer/buildsystem.h>
 #include <projectexplorer/projectnodes.h>
+#include "ros_build_configuration.h"
 
 namespace ROSProjectManager {
 namespace Internal {
@@ -28,6 +29,10 @@ public:
     virtual bool renameFile(ProjectExplorer::Node *context, const Utils::FilePath &oldFilePath, const Utils::FilePath &newFilePath) override final;
     virtual bool addDependencies(ProjectExplorer::Node *context, const QStringList &dependencies) override final;
     virtual bool supportsAction(ProjectExplorer::Node *context, ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const override final;
+    virtual QString name() const override final;
+
+private:
+    const ROSUtils::BuildSystem ros_build_system;
 };
 
 } // namespace Internal

--- a/src/project_manager/ros_catkin_make_step.cpp
+++ b/src/project_manager/ros_catkin_make_step.cpp
@@ -61,7 +61,7 @@ ROSCatkinMakeStep::ROSCatkinMakeStep(BuildStepList *parent, const Utils::Id id) 
     setDefaultDisplayName(QCoreApplication::translate("ROSProjectManager::Internal::ROSCatkinMakeStep",
                                                       ROS_CMS_DISPLAY_NAME));
 
-    m_percentProgress = QRegExp(QLatin1String("\\[\\s{0,2}(\\d{1,3})%\\]")); // Example: [ 82%] [ 82%] [ 87%]
+    m_percentProgress = QRegularExpression(QLatin1String("\\[\\s{0,2}(\\d{1,3})%\\]")); // Example: [ 82%] [ 82%] [ 87%]
 
     ROSBuildConfiguration *bc = rosBuildConfiguration();
     if (bc->rosBuildSystem() != ROSUtils::CatkinMake)
@@ -205,14 +205,13 @@ Utils::CommandLine ROSCatkinMakeStep::makeCommand(const QString &args) const
 void ROSCatkinMakeStep::stdOutput(const QString &line)
 {
     AbstractProcessStep::stdOutput(line);
-    int pos = 0;
-    while ((pos = m_percentProgress.indexIn(line, pos)) != -1) {
+    QRegularExpressionMatchIterator i = m_percentProgress.globalMatch(line);
+    while (i.hasNext()) {
+        QRegularExpressionMatch match = i.next();
         bool ok = false;
-        int percent = m_percentProgress.cap(1).toInt(&ok);
+        const int percent = match.captured(1).toInt(&ok);
         if (ok)
           emit progress(percent, QString());
-
-        pos += m_percentProgress.matchedLength();
     }
 }
 

--- a/src/project_manager/ros_catkin_make_step.cpp
+++ b/src/project_manager/ros_catkin_make_step.cpp
@@ -197,7 +197,7 @@ QString ROSCatkinMakeStep::allArguments(ROSUtils::BuildType buildType, bool incl
 
 Utils::CommandLine ROSCatkinMakeStep::makeCommand(const QString &args) const
 {
-    Utils::CommandLine cmd(QLatin1String("catkin_make"));
+    Utils::CommandLine cmd("catkin_make");
     cmd.addArgs(args, Utils::CommandLine::RawType::Raw);
     return cmd;
 }

--- a/src/project_manager/ros_catkin_make_step.h
+++ b/src/project_manager/ros_catkin_make_step.h
@@ -74,7 +74,7 @@ private:
     QString m_catkinMakeArguments;
     QString m_cmakeArguments;
     QString m_makeArguments;
-    QRegExp m_percentProgress;
+    QRegularExpression m_percentProgress;
 };
 
 class ROSCatkinMakeStepWidget : public QWidget

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -367,7 +367,8 @@ void ROSCatkinToolsStepWidget::updateDetails()
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
     ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->rosBuildSystem(), bc->project()->distribution());
 
-    m_ui->catkinToolsWorkingDirWidget->setEnvironment(bc->environment());
+    m_ui->catkinToolsWorkingDirWidget->setEnvironmentChange(
+                Utils::EnvironmentChange::fromFixedEnvironment(bc->environment()));
 
     ProcessParameters param;
     param.setMacroExpander(bc->macroExpander());

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -72,7 +72,7 @@ ROSCatkinToolsStep::ROSCatkinToolsStep(BuildStepList *parent, const Utils::Id id
     if (m_activeProfile.isEmpty())
         m_activeProfile = "default";
 
-    m_percentProgress = QRegExp(QLatin1String(".+\\[(\\d+)/(\\d+) complete\\]")); // Example: [0/24 complete]
+    m_percentProgress = QRegularExpression(QLatin1String(".+\\[(\\d+)/(\\d+) complete\\]")); // Example: [0/24 complete]
 
     ROSBuildConfiguration *bc = rosBuildConfiguration();
     if (bc->rosBuildSystem() != ROSUtils::CatkinTools)
@@ -232,10 +232,11 @@ Utils::CommandLine ROSCatkinToolsStep::makeCommand(const QString &args) const
 void ROSCatkinToolsStep::stdOutput(const QString &line)
 {
     AbstractProcessStep::stdOutput(line);
-    if (m_percentProgress.indexIn(line, 0) != -1)
-    {
+    QRegularExpressionMatchIterator i = m_percentProgress.globalMatch(line);
+    while (i.hasNext()) {
+        QRegularExpressionMatch match = i.next();
         bool ok = false;
-        int percent = (m_percentProgress.cap(1).toDouble(&ok)/m_percentProgress.cap(2).toDouble(&ok)) * 100.0;
+        const int percent = (match.captured(1).toDouble(&ok)/match.captured(2).toDouble(&ok)) * 100.0;
         if (ok)
           emit progress(percent, QString());
     }

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -224,7 +224,7 @@ QString ROSCatkinToolsStep::allArguments(ROSUtils::BuildType buildType, bool inc
 
 Utils::CommandLine ROSCatkinToolsStep::makeCommand(const QString &args) const
 {
-    Utils::CommandLine cmd(QLatin1String("catkin"));
+    Utils::CommandLine cmd("catkin");
     cmd.addArgs(args, Utils::CommandLine::RawType::Raw);
     return cmd;
 }

--- a/src/project_manager/ros_catkin_tools_step.h
+++ b/src/project_manager/ros_catkin_tools_step.h
@@ -89,7 +89,7 @@ private:
     QString m_cmakeArguments;
     QString m_makeArguments;
     QString m_catkinToolsWorkingDir;
-    QRegExp m_percentProgress;
+    QRegularExpression m_percentProgress;
 };
 
 class ROSCatkinToolsStepWidget : public QWidget

--- a/src/project_manager/ros_colcon_step.cpp
+++ b/src/project_manager/ros_colcon_step.cpp
@@ -61,7 +61,7 @@ ROSColconStep::ROSColconStep(BuildStepList *parent, const Utils::Id id) :
     setDefaultDisplayName(QCoreApplication::translate("ROSProjectManager::Internal::ROSColconStep",
                                                       ROS_COLCON_STEP_DISPLAY_NAME));
 
-    m_percentProgress = QRegExp(QLatin1String(".+\\[(\\d+)/(\\d+) complete\\]")); // Example: [0/24 complete]
+    m_percentProgress = QRegularExpression(QLatin1String(".+\\[(\\d+)/(\\d+) complete\\]")); // Example: [0/24 complete]
 
     ROSBuildConfiguration *bc = rosBuildConfiguration();
     if (bc->rosBuildSystem() != ROSUtils::Colcon)
@@ -216,10 +216,11 @@ Utils::CommandLine ROSColconStep::makeCommand(const QString &args) const
 void ROSColconStep::stdOutput(const QString &line)
 {
     AbstractProcessStep::stdOutput(line);
-    if (m_percentProgress.indexIn(line, 0) != -1)
-    {
+    QRegularExpressionMatchIterator i = m_percentProgress.globalMatch(line);
+    while (i.hasNext()) {
+        QRegularExpressionMatch match = i.next();
         bool ok = false;
-        int percent = (m_percentProgress.cap(1).toDouble(&ok)/m_percentProgress.cap(2).toDouble(&ok)) * 100.0;
+        const int percent = (match.captured(1).toDouble(&ok)/match.captured(2).toDouble(&ok)) * 100.0;
         if (ok)
           emit progress(percent, QString());
     }

--- a/src/project_manager/ros_colcon_step.cpp
+++ b/src/project_manager/ros_colcon_step.cpp
@@ -195,16 +195,16 @@ QString ROSColconStep::allArguments(ROSUtils::BuildType buildType, bool includeD
 
 Utils::CommandLine ROSColconStep::makeCommand(const QString &args) const
 {
-    QLatin1String exec;
+    Utils::FilePath exec;
     switch(m_target) {
     case BUILD:
-        exec = QLatin1String("colcon");
+        exec = "colcon";
         break;
     case CLEAN:
-        exec = QLatin1String("rm");
+        exec = "rm";
         break;
     default:
-        exec = QLatin1String("colcon");
+        exec = "colcon";
         break;
     }
 

--- a/src/project_manager/ros_colcon_step.h
+++ b/src/project_manager/ros_colcon_step.h
@@ -75,7 +75,7 @@ private:
     QString m_colconArguments;
     QString m_cmakeArguments;
     QString m_makeArguments;
-    QRegExp m_percentProgress;
+    QRegularExpression m_percentProgress;
 };
 
 class ROSColconStepWidget : public QWidget

--- a/src/project_manager/ros_generic_run_step.cpp
+++ b/src/project_manager/ros_generic_run_step.cpp
@@ -111,6 +111,7 @@ void ROSGenericRunStep::run()
        Core::MessageManager::writeFlashing(tr("[ROS Error] The shell: %1 is currently not supported (Use bash, sh, or zsh)!").arg(shell.toString()));
   }
 
+#ifdef ROSTERMINAL
   //create terminal without starting shell
   QTermWidget &terminal = ROSProjectPlugin::instance()->startTerminal(0, command);
 
@@ -124,6 +125,7 @@ void ROSGenericRunStep::run()
 
   //send roslaunch command
   terminal.sendText(command);
+#endif
 }
 
 QVariantMap ROSGenericRunStep::toMap() const

--- a/src/project_manager/ros_package_wizard.cpp
+++ b/src/project_manager/ros_package_wizard.cpp
@@ -189,7 +189,7 @@ void ROSPackageWizardDetailsPage::slotActivated()
 
 QStringList ROSPackageWizardDetailsPage::processList(const QString &text) const
 {
-    return text.split(QRegExp(QLatin1String("[,; ]")), Qt::SkipEmptyParts);
+    return text.split(QRegularExpression(QLatin1String("[,; ]")), Qt::SkipEmptyParts);
 }
 
 bool ROSPackageWizardDetailsPage::validateWithValidator(Utils::FancyLineEdit *edit, QString *errorMessage)

--- a/src/project_manager/ros_package_wizard.cpp
+++ b/src/project_manager/ros_package_wizard.cpp
@@ -234,7 +234,7 @@ ROSPackageWizard::ROSPackageWizard()
 
 Core::BaseFileWizard *ROSPackageWizard::create(QWidget *parent, const Core::WizardDialogParameters &parameters) const
 {
-    Utils::FilePath defaultPath = Utils::FilePath::fromString(parameters.defaultPath());
+    Utils::FilePath defaultPath = parameters.defaultPath();
 
     ROSProject *rosProject = qobject_cast<ROSProject *>(ProjectExplorer::ProjectTree::currentProject());
 

--- a/src/project_manager/ros_packagexml_parser.cpp
+++ b/src/project_manager/ros_packagexml_parser.cpp
@@ -39,7 +39,7 @@ bool ROSPackageXmlParser::parsePackageXml(const Utils::FilePath &filepath)
 
         while (!atEnd()) {
             readNext();
-            if (name() == "package")
+            if (name().toString() == "package")
                 parse();
             else if (isStartElement())
                 parseUnknownElement();
@@ -66,33 +66,33 @@ void ROSPackageXmlParser::parse()
         readNext();
         if (isEndElement())
             return;
-        else if (name() == "name")
+        else if (name().toString() == "name")
             parseName();
-        else if (name() == "version")
+        else if (name().toString() == "version")
             parseVersion();
-        else if (name() == "description")
+        else if (name().toString() == "description")
             parseDescription();
-        else if (name() == "maintainer")
+        else if (name().toString() == "maintainer")
             parseMaintainer();
-        else if (name() == "license")
+        else if (name().toString() == "license")
             parseLicense();
-        else if (name() == "depend")
+        else if (name().toString() == "depend")
             parseDepend();
-        else if (name() == "build_depend")
+        else if (name().toString() == "build_depend")
             parseBuildDepend();
-        else if (name() == "buildtool_depend")
+        else if (name().toString() == "buildtool_depend")
             parseBuildToolDepend();
-        else if (name() == "build_export_depend")
+        else if (name().toString() == "build_export_depend")
             parseBuildExportDepend();
-        else if (name() == "exec_depend")
+        else if (name().toString() == "exec_depend")
             parseExecDepend();
-        else if (name() == "run_depend")
+        else if (name().toString() == "run_depend")
             parseExecDepend();
-        else if (name() == "test_depend")
+        else if (name().toString() == "test_depend")
             parseTestDepend();
-        else if (name() == "doc_depend")
+        else if (name().toString() == "doc_depend")
             parseDocDepend();
-        else if (name() == "export")
+        else if (name().toString() == "export")
             parseExport();
         else if (isStartElement())
             parseUnknownElement();
@@ -183,7 +183,7 @@ void ROSPackageXmlParser::parseExport()
         readNext();
         if (isEndElement())
             return;
-        else if (name() == "metapackage")
+        else if (name().toString() == "metapackage")
             parseMetapackage();
         else if (isStartElement())
             parseUnknownElement();

--- a/src/project_manager/ros_project.cpp
+++ b/src/project_manager/ros_project.cpp
@@ -366,7 +366,11 @@ void ROSProject::fileSystemChanged(const QString &path)
 
 void ROSProject::asyncUpdate()
 {
-  rosBuildConfiguration()->buildSystem()->requestParse();
+  ROSBuildConfiguration *bc = rosBuildConfiguration();
+  if (!bc)
+    return;
+
+  bc->buildSystem()->requestParse();
 
   m_futureWatcher.waitForFinished();
 
@@ -388,8 +392,8 @@ void ROSProject::asyncUpdate()
   m_futureWatcher.setFuture(m_asyncUpdateFutureInterface->future());
 
   Utils::runAsync(ProjectExplorer::ProjectExplorerPlugin::sharedThreadPool(), QThread::LowestPriority,
-    [this]() {
-      Utils::FilePath sourcePath = ROSUtils::getWorkspaceInfo(projectDirectory(), rosBuildConfiguration()->rosBuildSystem(), distribution()).sourcePath;
+    [this, bc]() {
+      Utils::FilePath sourcePath = ROSUtils::getWorkspaceInfo(projectDirectory(), bc->rosBuildSystem(), distribution()).sourcePath;
       ROSProject::buildProjectTree(projectFilePath(), sourcePath, *m_asyncUpdateFutureInterface);
     });
 }

--- a/src/project_manager/ros_project.cpp
+++ b/src/project_manager/ros_project.cpp
@@ -31,9 +31,9 @@
 #include <coreplugin/vcsmanager.h>
 #include <coreplugin/progressmanager/progressmanager.h>
 #include <coreplugin/messagemanager.h>
-#include <cpptools/cpptoolsconstants.h>
-#include <cpptools/cppmodelmanager.h>
-#include <cpptools/projectinfo.h>
+#include <cppeditor/cppeditorconstants.h>
+#include <cppeditor/cppmodelmanager.h>
+#include <cppeditor/projectinfo.h>
 #include <extensionsystem/pluginmanager.h>
 #include <projectexplorer/abi.h>
 #include <projectexplorer/buildsteplist.h>
@@ -58,7 +58,7 @@
 #include <QtConcurrentRun>
 #include <QRegularExpression>
 
-#include <cpptools/cppprojectupdater.h>
+#include <cppeditor/cppprojectupdater.h>
 
 using namespace Core;
 using namespace ProjectExplorer;
@@ -127,7 +127,7 @@ const int UPDATE_INTERVAL = 300;
 
 ROSProject::ROSProject(const Utils::FilePath &fileName) :
     ProjectExplorer::Project(Constants::ROS_MIME_TYPE, fileName),
-    m_cppCodeModelUpdater(new CppTools::CppProjectUpdater),
+    m_cppCodeModelUpdater(new CppEditor::CppProjectUpdater),
     m_project_loaded(false),
     m_asyncUpdateFutureInterface(nullptr),
     m_asyncBuildCodeModelFutureInterface(nullptr)

--- a/src/project_manager/ros_project.h
+++ b/src/project_manager/ros_project.h
@@ -39,7 +39,7 @@
 #include <QTimer>
 #include <QFileSystemWatcher>
 
-namespace CppTools {
+namespace CppEditor {
     class CppProjectUpdater;
 }
 
@@ -88,7 +88,7 @@ private:
     ROSUtils::PackageInfoMap        m_wsPackageInfo;
     ROSUtils::PackageBuildInfoMap   m_wsPackageBuildInfo;
 
-    CppTools::CppProjectUpdater *m_cppCodeModelUpdater;
+    CppEditor::CppProjectUpdater *m_cppCodeModelUpdater;
 
     // Watching Directories to keep Project Tree updated
     QTimer m_asyncUpdateTimer;

--- a/src/project_manager/ros_project_nodes.cpp
+++ b/src/project_manager/ros_project_nodes.cpp
@@ -60,7 +60,7 @@ bool ROSProjectNode::showInSimpleTree() const
 
 ROSFolderNode::ROSFolderNode(const Utils::FilePath &folderPath) : FolderNode(folderPath), m_repository(nullptr)
 {
-    QString path = this->filePath().toString();
+    const Utils::FilePath path = this->filePath();
 
     if (Core::IVersionControl *vc = Core::VcsManager::findVersionControlForDirectory(path))
     {
@@ -75,9 +75,8 @@ QString ROSFolderNode::displayName() const
 {
     if (m_repository)
     {
-        QString path = this->filePath().toString();
-        QString name = Utils::FilePath::fromString(path).fileName();
-        return QString::fromLatin1("%1 [%2]").arg(name, m_repository->vcsTopic(path));
+        const Utils::FilePath path = this->filePath();
+        return QString::fromLatin1("%1 [%2]").arg(path.fileName(), m_repository->vcsTopic(path));
     }
     else
     {

--- a/src/project_manager/ros_project_plugin.cpp
+++ b/src/project_manager/ros_project_plugin.cpp
@@ -19,7 +19,9 @@
  * limitations under the License.
  */
 #include "ros_project_plugin.h"
+#ifdef ROSTERMINAL
 #include "ros_terminal_pane.h"
+#endif
 #include "ros_build_configuration.h"
 #include "ros_run_configuration.h"
 #include "ros_rosrun_step.h"
@@ -109,7 +111,9 @@ public:
     ROSCatkinToolsStepFactory catkinToolsStepFactory;
     ROSColconStepFactory colconStepFactory;
 
+#ifdef ROSTERMINAL
     ROSTerminalPane terminalPane;
+#endif
 
     QSharedPointer<ROSSettings> settings;
     QSharedPointer<ROSSettingsPage> settingsPage;
@@ -122,7 +126,9 @@ ROSProjectPlugin::ROSProjectPlugin() : ExtensionSystem::IPlugin()
 
 ROSProjectPlugin::~ROSProjectPlugin()
 {
+#ifdef ROSTERMINAL
   ExtensionSystem::PluginManager::removeObject(&(d->terminalPane));
+#endif
   delete d;
   m_instance = nullptr;
 }
@@ -137,7 +143,9 @@ bool ROSProjectPlugin::initialize(const QStringList &, QString *errorMessage)
     Q_UNUSED(errorMessage);
 
     d = new ROSProjectPluginPrivate();
+#ifdef ROSTERMINAL
     ExtensionSystem::PluginManager::addObject(&(d->terminalPane));
+#endif
 
     QFile mimeFilePath(":rosproject/ROSProjectManager.mimetypes.xml");
 
@@ -189,10 +197,12 @@ bool ROSProjectPlugin::initialize(const QStringList &, QString *errorMessage)
     return true;
 }
 
+#ifdef ROSTERMINAL
 QTermWidget &ROSProjectPlugin::startTerminal(int startnow, const QString name)
 {
   return d->terminalPane.startTerminal(startnow, name);
 }
+#endif
 
 QSharedPointer<ROSSettings> ROSProjectPlugin::settings() const
 {

--- a/src/project_manager/ros_project_plugin.cpp
+++ b/src/project_manager/ros_project_plugin.cpp
@@ -45,9 +45,9 @@
 #include <coreplugin/actionmanager/command.h>
 #include <coreplugin/progressmanager/progressmanager.h>
 
-#include <cpptools/cppcodestylepreferences.h>
-#include <cpptools/cpptoolssettings.h>
-#include <cpptools/cpptoolsconstants.h>
+#include <cppeditor/cppcodestylepreferences.h>
+#include <cppeditor/cpptoolssettings.h>
+#include <cppeditor/cppeditorconstants.h>
 
 #include <texteditor/codestylepool.h>
 #include <texteditor/tabsettings.h>
@@ -201,10 +201,10 @@ QSharedPointer<ROSSettings> ROSProjectPlugin::settings() const
 
 void ROSProjectPlugin::createCppCodeStyle()
 {
-  TextEditor::CodeStylePool *pool = TextEditor::TextEditorSettings::codeStylePool(CppTools::Constants::CPP_SETTINGS_ID);
+  TextEditor::CodeStylePool *pool = TextEditor::TextEditorSettings::codeStylePool(CppEditor::Constants::CPP_SETTINGS_ID);
 
   // ROS style
-  CppTools::CppCodeStylePreferences *rosCodeStyle = new CppTools::CppCodeStylePreferences();
+  CppEditor::CppCodeStylePreferences *rosCodeStyle = new CppEditor::CppCodeStylePreferences();
   rosCodeStyle->setId(Constants::ROS_CPP_CODE_STYLE_ID);
   rosCodeStyle->setDisplayName(tr("ROS"));
   rosCodeStyle->setReadOnly(true);
@@ -216,7 +216,7 @@ void ROSProjectPlugin::createCppCodeStyle()
   rosTabSettings.m_continuationAlignBehavior = TextEditor::TabSettings::ContinuationAlignWithIndent;
   rosCodeStyle->setTabSettings(rosTabSettings);
 
-  CppTools::CppCodeStyleSettings rosCodeStyleSettings;
+  CppEditor::CppCodeStyleSettings rosCodeStyleSettings;
   rosCodeStyleSettings.alignAssignments = false;
   rosCodeStyleSettings.bindStarToIdentifier = true;
   rosCodeStyleSettings.bindStarToLeftSpecifier = false;
@@ -244,8 +244,8 @@ void ROSProjectPlugin::createCppCodeStyle()
   // Since the ROS Cpp code style can not be added until after the CppToolsSettings instance is create
   // the Cpp code style must be reloaded from settings to capture if it is set ROS Cpp code style.
   QSettings *s = Core::ICore::settings();
-  CppTools::CppCodeStylePreferences *originalCppCodeStylePreferences = CppTools::CppToolsSettings::instance()->cppCodeStyle();
-  originalCppCodeStylePreferences->fromSettings(QLatin1String(CppTools::Constants::CPP_SETTINGS_ID), s);
+  CppEditor::CppCodeStylePreferences *originalCppCodeStylePreferences = CppEditor::CppToolsSettings::instance()->cppCodeStyle();
+  originalCppCodeStylePreferences->fromSettings(QLatin1String(CppEditor::Constants::CPP_SETTINGS_ID), s);
 }
 
 void ROSProjectPlugin::reloadProjectBuildInfo()

--- a/src/project_manager/ros_project_plugin.h
+++ b/src/project_manager/ros_project_plugin.h
@@ -23,7 +23,9 @@
 #include <extensionsystem/iplugin.h>
 #include <QObject>
 #include <QAction>
+#ifdef ROSTERMINAL
 #include <qtermwidget5/qtermwidget.h>
+#endif
 
 namespace ProjectExplorer {
 class Project;
@@ -48,6 +50,7 @@ public:
 
     static ROSProjectPlugin *instance();
 
+#ifdef ROSTERMINAL
     /**
      * @brief Start a terminal in the tabbed terminal widget
      * @param startnow If 1 the terminal shell is started
@@ -55,6 +58,7 @@ public:
      * @return A a reference to the created terminal
      */
     QTermWidget &startTerminal(int startnow = 1, const QString name = QString());
+#endif
 
     /**
      * @brief Get ROS Main settings

--- a/src/project_manager/ros_project_plugin.h
+++ b/src/project_manager/ros_project_plugin.h
@@ -33,7 +33,7 @@ class Node;
 namespace ROSProjectManager {
 namespace Internal {
 
-class ROSSettings;
+struct ROSSettings;
 
 class ROSProjectPlugin : public ExtensionSystem::IPlugin
 {

--- a/src/project_manager/ros_project_wizard.cpp
+++ b/src/project_manager/ros_project_wizard.cpp
@@ -31,8 +31,8 @@
 #include <projectexplorer/editorconfiguration.h>
 #include <projectexplorer/project.h>
 
-#include <cpptools/cppcodestylepreferences.h>
-#include <cpptools/cpptoolsconstants.h>
+#include <cppeditor/cppcodestylepreferences.h>
+#include <cppeditor/cppeditorconstants.h>
 
 #include <texteditor/icodestylepreferences.h>
 #include <texteditor/texteditorsettings.h>
@@ -290,12 +290,12 @@ bool ROSProjectWizard::postGenerateFiles(const QWizard *w, const Core::Generated
 
     // Set the Cpp code style for the project.
     QSharedPointer<ROSSettings> ros_settings = ROSProjectPlugin::instance()->settings();
-    TextEditor::CodeStylePool *code_style_pool = TextEditor::TextEditorSettings::codeStylePool(CppTools::Constants::CPP_SETTINGS_ID);
+    TextEditor::CodeStylePool *code_style_pool = TextEditor::TextEditorSettings::codeStylePool(CppEditor::Constants::CPP_SETTINGS_ID);
 
     for (const auto& code_style : code_style_pool->codeStyles()) {
         if (ros_settings->default_code_style == code_style->displayName()) {
             ProjectExplorer::EditorConfiguration *editorConfiguration = project->editorConfiguration();
-            TextEditor::ICodeStylePreferences *codeStylePreferences = editorConfiguration->codeStyle(CppTools::Constants::CPP_SETTINGS_ID);
+            TextEditor::ICodeStylePreferences *codeStylePreferences = editorConfiguration->codeStyle(CppEditor::Constants::CPP_SETTINGS_ID);
             codeStylePreferences->setCurrentDelegate(code_style->id());
             break;
         }

--- a/src/project_manager/ros_run_configuration.cpp
+++ b/src/project_manager/ros_run_configuration.cpp
@@ -220,10 +220,10 @@ void ROSDebugRunWorker::pidFound(ProjectExplorer::DeviceProcessItem process)
 void ROSDebugRunWorker::findProcess()
 {
     m_timeElapsed += 10;
-    const QString &appName = Utils::FileUtils::normalizePathName(m_debugTargetPath);
+    const QString &appName = Utils::FileUtils::normalizedPathName(m_debugTargetPath);
     ProjectExplorer::DeviceProcessItem fallback;
     for (const ProjectExplorer::DeviceProcessItem &p : ProjectExplorer::DeviceProcessList::localProcesses()) {
-        if (Utils::FileUtils::normalizePathName(p.exe) == appName) {
+        if (Utils::FileUtils::normalizedPathName(p.exe) == appName) {
             Core::MessageManager::writeSilently(tr("[ROS] Attaching to process: %1.").arg(appName));
             pidFound(p);
             return;

--- a/src/project_manager/ros_run_steps_page.cpp
+++ b/src/project_manager/ros_run_steps_page.cpp
@@ -48,7 +48,6 @@ namespace Internal {
 ToolWidget::ToolWidget(QWidget *parent) : FadingPanel(parent)
 {
     auto layout = new QHBoxLayout;
-    layout->setMargin(4);
     layout->setSpacing(4);
     setLayout(layout);
     m_firstWidget = new Utils::FadingWidget(this);
@@ -71,7 +70,6 @@ ToolWidget::ToolWidget(QWidget *parent) : FadingPanel(parent)
     m_secondWidget = new Utils::FadingWidget(this);
     m_secondWidget->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
     hbox = new QHBoxLayout();
-    hbox->setMargin(0);
     hbox->setSpacing(4);
     m_secondWidget->setLayout(hbox);
 
@@ -444,7 +442,6 @@ RunStepsPage::RunStepsPage(ROSRunConfiguration *rc, Utils::Id id) :
     m_widget(new RunStepListWidget(this))
 {
     QVBoxLayout *layout = new QVBoxLayout(this);
-    layout->setMargin(0);
     layout->setSpacing(0);
     layout->addWidget(m_widget);
 

--- a/src/project_manager/ros_settings_page.cpp
+++ b/src/project_manager/ros_settings_page.cpp
@@ -31,7 +31,7 @@
 #include <texteditor/texteditorsettings.h>
 #include <texteditor/codestylepool.h>
 
-#include <cpptools/cpptoolsconstants.h>
+#include <cppeditor/cppeditorconstants.h>
 
 #include <projectexplorer/projectexplorerconstants.h>
 
@@ -128,7 +128,7 @@ ROSSettingsWidget::ROSSettingsWidget(QWidget *parent) :
 
     // See ProjectExplorer::CodeStyleSettingsWidget and ProjectExplorer::EditorConfiguration as an example
     // TODO: Add python support
-    TextEditor::CodeStylePool *code_style_pool = TextEditor::TextEditorSettings::codeStylePool(CppTools::Constants::CPP_SETTINGS_ID);
+    TextEditor::CodeStylePool *code_style_pool = TextEditor::TextEditorSettings::codeStylePool(CppEditor::Constants::CPP_SETTINGS_ID);
 
     for (const auto& code_style : code_style_pool->builtInCodeStyles()) {
         QString name = code_style->displayName() + " [built-in]";

--- a/src/project_manager/ros_terminal_pane.cpp
+++ b/src/project_manager/ros_terminal_pane.cpp
@@ -140,7 +140,7 @@ void ROSTerminalPane::closeTerminal(int index)
 
   // Need to kill the shell process
   QTermWidget* terminal = qobject_cast<QTermWidget*>(m_tabWidget->currentWidget());
-  QProcess::startDetached(QString("kill"), QStringList() << "-9" << QString(terminal->getShellPID()));
+  QProcess::startDetached(QString("kill"), QStringList() << "-9" << QString::number(terminal->getShellPID()));
 
   m_terminals.removeAll(terminal);
   m_tabWidget->removeTab(index);

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -333,7 +333,7 @@ bool ROSUtils::sourceWorkspaceHelper(QProcess *process, const QString &path)
   if (process->exitStatus() != QProcess::CrashExit)
   {
     QString output = QString::fromStdString(process->readAllStandardOutput().toStdString());
-    env_list = output.split(QRegExp("[\r\n]"), Qt::SkipEmptyParts);
+    env_list = output.split(QRegularExpression("[\r\n]"), Qt::SkipEmptyParts);
 
     Utils::Environment env(env_list);
     process->setProcessEnvironment(env.toProcessEnvironment());
@@ -833,7 +833,7 @@ QMap<QString, QString> ROSUtils::getROSPackages(const QStringList &env)
   if (process.exitStatus() != QProcess::CrashExit)
   {
     QString output = QString::fromStdString(process.readAllStandardOutput().toStdString());
-    QStringList package_list = output.split(QRegExp("[\r\n]"), Qt::SkipEmptyParts);
+    QStringList package_list = output.split(QRegularExpression("[\r\n]"), Qt::SkipEmptyParts);
 
     for (const QString& str : package_list)
     {
@@ -903,7 +903,7 @@ QMap<QString, QString> ROSUtils::getROSPackageExecutables(const QString &package
   if (process.exitStatus() != QProcess::CrashExit)
   {
     QString output = QString::fromStdString(process.readAllStandardOutput().toStdString());
-    QStringList loc_list = output.split(QRegExp("[\r\n]"), Qt::SkipEmptyParts);
+    QStringList loc_list = output.split(QRegularExpression("[\r\n]"), Qt::SkipEmptyParts);
 
     if (loc_list.size() > 0)
     {

--- a/src/project_manager/ros_utils.h
+++ b/src/project_manager/ros_utils.h
@@ -102,7 +102,8 @@ public:
         QStringList flags;         /**< @brief Target's cxx build flags */
         QStringList defines;       /**< @brief Target's defines build flags */
     };
-    typedef QList<PackageTargetInfo> PackageTargetInfoList;
+    typedef std::shared_ptr<PackageTargetInfo> PackageTargetInfoPtr;
+    typedef QList<PackageTargetInfoPtr> PackageTargetInfoList;
 
     /** @brief Contains all relevant package information */
     struct PackageInfo {

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,5 +1,7 @@
-qtc_version: "5.0"
+# see https://download.qt.io/development_releases/qtcreator for valid versions
+# the version schema is: {major}.{minor}[-{devel}]
+qtc_version: "6.0"
 qtc_modules: ["qtcreator", "qtcreator_dev"]
 
-qt_version: "5.15"
-qt_modules: ['qtbase', 'qtdeclarative', 'icu', 'qttools']
+qt_version: "6.2"
+qt_modules: ['qtbase', 'qtdeclarative', 'icu', 'qttools', 'qt5compat']


### PR DESCRIPTION
~~This is the initial port for [Qt Creator 6 Beta](https://www.qt.io/blog/qt-creator-6-beta-released). I am going to keep this as a draft until it has been officially released. But you can already review and comment now.~~

Port for [Qt Creator 6](https://www.qt.io/blog/qt-creator-6-released).

Notable changes are:
1. switch to Qt6
2. temporary deactivation of the ROS Terminal (qtermwidget) due to missing support for Qt6, I tried to use the Qt5 version but this seem to crash Qt Creator with something related to the Qt5 compatibility layer
3. without qtermwidget, which is not available on Windows, I am also building the Windows plugin in the CI, the plugin itself does not load correctly, presumably because if missing symbols, but having the CI run with MSVC already provides some useful warnings and error messages