### PR TITLE
Qt Creator 8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(ROSProjectManager VERSION 0.6.0)
+project(ROSProjectManager VERSION 8.0)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     add_link_options("-Wl,-z,relro,-z,now,-z,defs")

--- a/src/project_manager/ros_build_configuration.cpp
+++ b/src/project_manager/ros_build_configuration.cpp
@@ -34,7 +34,6 @@
 #include <projectexplorer/kitinformation.h>
 #include <projectexplorer/projectexplorerconstants.h>
 #include <projectexplorer/toolchain.h>
-#include <utils/mimetypes/mimedatabase.h>
 #include <utils/pathchooser.h>
 #include <utils/qtcassert.h>
 

--- a/src/project_manager/ros_package_wizard.cpp
+++ b/src/project_manager/ros_package_wizard.cpp
@@ -33,7 +33,6 @@
 #include <projectexplorer/projecttree.h>
 
 #include <utils/filewizardpage.h>
-#include <utils/mimetypes/mimedatabase.h>
 #include <utils/wizard.h>
 
 #include <QApplication>

--- a/src/project_manager/ros_project.cpp
+++ b/src/project_manager/ros_project.cpp
@@ -513,7 +513,7 @@ void ROSProject::buildCppCodeModel(const ROSUtils::WorkspaceInfo workspaceInfo,
                 QSet<QString> toolChainIncludes;
                 const HeaderPaths header_paths = \
                         cxxToolChain->createBuiltInHeaderPathsRunner(env)\
-                        (targetInfo->flags, sysRoot.toString(), QString());
+                        (targetInfo->flags, sysRoot, QString());
                 for (const HeaderPath &hp : header_paths) {
                     toolChainIncludes.insert(hp.path);
                 }

--- a/src/project_manager/ros_project_plugin.cpp
+++ b/src/project_manager/ros_project_plugin.cpp
@@ -72,6 +72,7 @@
 #include <utils/algorithm.h>
 #include <utils/fileutils.h>
 #include <utils/removefiledialog.h>
+#include <utils/mimeutils.h>
 
 #include <QtPlugin>
 #include <QDebug>

--- a/src/project_manager/ros_project_plugin.cpp
+++ b/src/project_manager/ros_project_plugin.cpp
@@ -73,7 +73,6 @@
 
 #include <utils/algorithm.h>
 #include <utils/fileutils.h>
-#include <utils/mimetypes/mimedatabase.h>
 #include <utils/removefiledialog.h>
 
 #include <QtPlugin>

--- a/src/project_manager/ros_project_plugin.cpp
+++ b/src/project_manager/ros_project_plugin.cpp
@@ -22,7 +22,6 @@
 #ifdef ROSTERMINAL
 #include "ros_terminal_pane.h"
 #endif
-#include "ros_build_configuration.h"
 #include "ros_run_configuration.h"
 #include "ros_rosrun_step.h"
 #include "ros_roslaunch_step.h"
@@ -35,7 +34,6 @@
 #include "ros_catkin_tools_step.h"
 #include "ros_colcon_step.h"
 #include "ros_project.h"
-#include "ros_utils.h"
 #include "ros_project_constants.h"
 #include "ros_package_wizard.h"
 #include "ros_settings_page.h"

--- a/src/project_manager/ros_project_wizard.cpp
+++ b/src/project_manager/ros_project_wizard.cpp
@@ -39,7 +39,6 @@
 #include <texteditor/codestylepool.h>
 
 #include <utils/filewizardpage.h>
-#include <utils/mimetypes/mimedatabase.h>
 #include <utils/wizard.h>
 #include <utils/icon.h>
 

--- a/src/project_manager/ros_run_configuration.cpp
+++ b/src/project_manager/ros_run_configuration.cpp
@@ -46,6 +46,7 @@
 #include <qmljstools/qmljstoolsconstants.h>
 #include <utils/detailswidget.h>
 #include <utils/utilsicons.h>
+#include <utils/processinfo.h>
 
 #include <QLineEdit>
 #include <QComboBox>
@@ -204,12 +205,12 @@ void ROSDebugRunWorker::start()
     }
 }
 
-void ROSDebugRunWorker::pidFound(ProjectExplorer::DeviceProcessItem process)
+void ROSDebugRunWorker::pidFound(const Utils::ProcessInfo &process)
 {
     m_timer.stop();
-    setAttachPid(Utils::ProcessHandle(process.pid));
-    setId(tr("Process %1").arg(process.pid));
-    setInferiorExecutable(Utils::FilePath::fromString(process.exe));
+    setAttachPid(Utils::ProcessHandle(process.processId));
+    setId(tr("Process %1").arg(process.processId));
+    setInferiorExecutable(Utils::FilePath::fromString(process.executable));
     setStartMode(Debugger::StartExternal);
     setCloseMode(Debugger::DetachAtClose);
     setContinueAfterAttach(m_debugContinueOnAttach);
@@ -220,17 +221,17 @@ void ROSDebugRunWorker::findProcess()
 {
     m_timeElapsed += 10;
     const QString &appName = Utils::FileUtils::normalizedPathName(m_debugTargetPath);
-    ProjectExplorer::DeviceProcessItem fallback;
-    for (const ProjectExplorer::DeviceProcessItem &p : ProjectExplorer::DeviceProcessList::localProcesses()) {
-        if (Utils::FileUtils::normalizedPathName(p.exe) == appName) {
+    Utils::ProcessInfo fallback;
+    for (const Utils::ProcessInfo &p : Utils::ProcessInfo::processInfoList()) {
+        if (Utils::FileUtils::normalizedPathName(p.executable) == appName) {
             Core::MessageManager::writeSilently(tr("[ROS] Attaching to process: %1.").arg(appName));
             pidFound(p);
             return;
         }
-        if (p.cmdLine.startsWith(appName))
+        if (p.commandLine.startsWith(appName))
             fallback = p;
     }
-    if (fallback.pid != 0)
+    if (fallback.processId != 0)
         pidFound(fallback);
 
     // Make sure this does not run indefinitely. Allow 30sec to start the process.

--- a/src/project_manager/ros_run_configuration.cpp
+++ b/src/project_manager/ros_run_configuration.cpp
@@ -129,7 +129,7 @@ ROSRunWorker::ROSRunWorker(RunControl *runControl) : RunWorker(runControl)
 
 void ROSRunWorker::start()
 {
-    for (RunStep *rs : qobject_cast<ROSRunConfiguration *>(runControl()->runConfiguration())->stepList()->steps())
+    for (RunStep *rs : qobject_cast<ROSRunConfiguration *>(runControl()->target()->activeRunConfiguration())->stepList()->steps())
     {
         if (rs->enabled() == true && rs->id() != ROSProjectManager::Constants::ROS_ATTACH_TO_NODE_ID)
         {
@@ -156,7 +156,7 @@ ROSDebugRunWorker::ROSDebugRunWorker(RunControl *runControl) : Debugger::Debugge
 void ROSDebugRunWorker::start()
 {
     bool found = false;
-    for (RunStep *rs : qobject_cast<ROSRunConfiguration *>(runControl()->runConfiguration())->stepList()->steps())
+    for (RunStep *rs : qobject_cast<ROSRunConfiguration *>(runControl()->target()->activeRunConfiguration())->stepList()->steps())
     {
         if (rs->enabled() == true && rs->id() == Constants::ROS_ATTACH_TO_NODE_ID)
         {
@@ -185,7 +185,7 @@ void ROSDebugRunWorker::start()
     if (found)
     {
         // Now that the watcher is started run all of the other steps
-        for (RunStep *rs : qobject_cast<ROSRunConfiguration *>(runControl()->runConfiguration())->stepList()->steps())
+        for (RunStep *rs : qobject_cast<ROSRunConfiguration *>(runControl()->target()->activeRunConfiguration())->stepList()->steps())
         {
             if (rs->enabled() == true && rs->id() != ROSProjectManager::Constants::ROS_ATTACH_TO_NODE_ID)
             {

--- a/src/project_manager/ros_run_configuration.cpp
+++ b/src/project_manager/ros_run_configuration.cpp
@@ -19,10 +19,7 @@
  * limitations under the License.
  */
 #include "ros_run_configuration.h"
-#include "ros_project.h"
-#include "ros_run_steps_page.h"
 #include "ros_generic_run_step.h"
-#include "ui_ros_run_configuration.h"
 
 #include <coreplugin/editormanager/editormanager.h>
 #include <coreplugin/editormanager/ieditor.h>

--- a/src/project_manager/ros_run_configuration.cpp
+++ b/src/project_manager/ros_run_configuration.cpp
@@ -34,6 +34,7 @@
 #include <projectexplorer/projectexplorer.h>
 #include <projectexplorer/projectexplorericons.h>
 #include <projectexplorer/buildstepspage.h>
+#include <projectexplorer/projectexplorerconstants.h>
 #include <debugger/debuggerengine.h>
 
 #include <qtsupport/qtkitinformation.h>

--- a/src/project_manager/ros_run_configuration.cpp
+++ b/src/project_manager/ros_run_configuration.cpp
@@ -41,7 +41,6 @@
 #include <qtsupport/qtsupportconstants.h>
 
 #include <utils/fileutils.h>
-#include <utils/mimetypes/mimedatabase.h>
 #include <utils/qtcprocess.h>
 #include <utils/winutils.h>
 #include <qmljstools/qmljstoolsconstants.h>

--- a/src/project_manager/ros_run_configuration.h
+++ b/src/project_manager/ros_run_configuration.h
@@ -92,7 +92,7 @@ public:
 
 private:
     void findProcess();
-    void pidFound(ProjectExplorer::DeviceProcessItem process);
+    void pidFound(const Utils::ProcessInfo &process);
     QTimer m_timer;
     int m_timeElapsed;
     QString m_debugTargetPath;

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,8 +3,8 @@
 # - https://download.qt.io/official_releases/qtcreator/
 # for valid versions
 # the version schema is: {major}.{minor}[-{devel}]
-qtc_version: "7.0"
+qtc_version: "8.0"
 qtc_modules: ["qtcreator", "qtcreator_dev"]
 
-qt_version: "6.2"
+qt_version: "6.3"
 qt_modules: ['qtbase', 'qtdeclarative', 'icu', 'qttools', 'qt5compat']


### PR DESCRIPTION
This updates the API to [Qt Creator 8](https://www.qt.io/blog/qt-creator-8-beta-released).

I am also aligning the version scheme with the one of the Qt Creator API. That means the next plugin version will be 8.0 as well. Since the API is guaranteed to be stable within a major Qt Creator release, we will continue to increment the major plugin version to be aligned with the Qt Creator major version. We can then use the minor version independently of Qt Creator for bug fix releases.