### PR TITLE
re-release with incremented minor version as workaround to ABI breakage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(ROSProjectManager VERSION 8.0)
+project(ROSProjectManager VERSION 8.1)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     add_link_options("-Wl,-z,relro,-z,now,-z,defs")

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,11 @@ def qtc_download_check_extract(cfg, dir_install):
         qtc_ver_type = None
 
     ver_split = qtc_ver_nr.split('.')
-    qtc_ver_maj = "{}.{}".format(ver_split[0], ver_split[1])
-    qtc_ver_full = "{}.{}.{}".format(ver_split[0], ver_split[1], 0)
+    qtc_ver_major = ver_split[0]
+    qtc_ver_minor = ver_split[1] if len(ver_split)>1 else 0
+    qtc_ver_patch = ver_split[2] if len(ver_split)>2 else 0
+    qtc_ver_maj = "{}.{}".format(qtc_ver_major, qtc_ver_minor)
+    qtc_ver_full = "{}.{}".format(qtc_ver_maj, qtc_ver_patch)
     if qtc_ver_type:
         qtc_ver_full = "{ver}-{type}".format(ver = qtc_ver_full, type = qtc_ver_type)
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,8 +2,8 @@
 # - https://download.qt.io/development_releases/qtcreator/
 # - https://download.qt.io/official_releases/qtcreator/
 # for valid versions
-# the version schema is: {major}.{minor}[-{devel}]
-qtc_version: "8.0"
+# the version schema is: {major}[.{minor}][.{patch}][-{devel}]
+qtc_version: "8.0.1"
 qtc_modules: ["qtcreator", "qtcreator_dev"]
 
 qt_version: "6.3"


### PR DESCRIPTION
Qt Creator 8 broke ABI compatibility between version 8.0.0 and 8.0.1 (https://bugreports.qt.io/browse/QTCREATORBUG-28075). Re-release the same version to compile against 8.0.1.

There is no functional change. Once this is merged, we will create a new `8.1` release for Qt Creator 8.0.1. The snap package is not affected since it compiles Qt Creator and the plugin from scratch anyway.

Fixes https://github.com/ros-industrial/ros_qtc_plugin/issues/466