### PR TITLE
downgrade Linux CI image to support older distributions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - { name: "Linux", os: ubuntu-latest }
+          - { name: "Linux", os: ubuntu-20.04 }
           - { name: "Windows", os: windows-latest }
           - { name: "macOS", os: macos-latest }
     outputs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(ROSProjectManager VERSION 9.0)
+project(ROSProjectManager VERSION 9.1)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     add_link_options("-Wl,-z,relro,-z,now,-z,defs")


### PR DESCRIPTION
Building with the `ubuntu-latest` runner currently builds on Ubuntu 22.04 with glibc 2.35. This makes the binary build artefacts incompatible with older distributions that use an older glibc version, such as Ubuntu 20.04 (Fixes https://github.com/ros-industrial/ros_qtc_plugin/issues/475).

As a short-term solution, we can use an older GitHub Action runner for Linux. In the long term, we should use a Docker container to build the binary distributed plugin archives.