### PR TITLE
Qt Creator 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(ROSProjectManager VERSION 9.1)
+project(ROSProjectManager VERSION 10.0)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     add_link_options("-Wl,-z,relro,-z,now,-z,defs")

--- a/src/project_manager/ros_build_configuration.ui
+++ b/src/project_manager/ros_build_configuration.ui
@@ -34,6 +34,9 @@
        <height>0</height>
       </size>
      </property>
+     <property name="currentIndex">
+      <number>2</number>
+     </property>
      <item>
       <property name="text">
        <string>CatkinMake</string>

--- a/src/project_manager/ros_catkin_make_step.cpp
+++ b/src/project_manager/ros_catkin_make_step.cpp
@@ -66,6 +66,11 @@ ROSCatkinMakeStep::ROSCatkinMakeStep(BuildStepList *parent, const Utils::Id id) 
     ROSBuildConfiguration *bc = rosBuildConfiguration();
     if (bc->rosBuildSystem() != ROSUtils::CatkinMake)
         setEnabled(false);
+
+    connect(this, &BuildStep::addOutput, this, [this](const QString &string, OutputFormat format) {
+        if (format == OutputFormat::Stdout)
+            stdOutput(string);
+    });
 }
 
 ROSBuildConfiguration *ROSCatkinMakeStep::rosBuildConfiguration() const
@@ -204,7 +209,6 @@ Utils::CommandLine ROSCatkinMakeStep::makeCommand(const QString &args) const
 
 void ROSCatkinMakeStep::stdOutput(const QString &line)
 {
-    AbstractProcessStep::stdOutput(line);
     QRegularExpressionMatchIterator i = m_percentProgress.globalMatch(line);
     while (i.hasNext()) {
         QRegularExpressionMatch match = i.next();

--- a/src/project_manager/ros_catkin_make_step.h
+++ b/src/project_manager/ros_catkin_make_step.h
@@ -58,7 +58,6 @@ public:
     void setBuildTarget(const BuildTargets &target);
     QString allArguments(ROSUtils::BuildType buildType, bool includeDefault = true) const;
     Utils::CommandLine makeCommand(const QString &args) const;
-    void stdOutput(const QString &line) override;
 
     QVariantMap toMap() const override;
 
@@ -69,6 +68,7 @@ protected:
 
 private:
     ROSBuildConfiguration *targetsActiveBuildConfiguration() const;
+    void stdOutput(const QString &line);
 
     BuildTargets m_target;
     QString m_catkinMakeArguments;

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -367,8 +367,7 @@ void ROSCatkinToolsStepWidget::updateDetails()
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
     ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->rosBuildSystem(), bc->project()->distribution());
 
-    m_ui->catkinToolsWorkingDirWidget->setEnvironmentChange(
-                Utils::EnvironmentChange::fromFixedEnvironment(bc->environment()));
+    m_ui->catkinToolsWorkingDirWidget->setEnvironment(bc->environment());
 
     ProcessParameters param;
     param.setMacroExpander(bc->macroExpander());

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -77,6 +77,11 @@ ROSCatkinToolsStep::ROSCatkinToolsStep(BuildStepList *parent, const Utils::Id id
     ROSBuildConfiguration *bc = rosBuildConfiguration();
     if (bc->rosBuildSystem() != ROSUtils::CatkinTools)
         setEnabled(false);
+
+    connect(this, &BuildStep::addOutput, this, [this](const QString &string, OutputFormat format) {
+        if (format == OutputFormat::Stdout)
+            stdOutput(string);
+    });
 }
 
 ROSBuildConfiguration *ROSCatkinToolsStep::rosBuildConfiguration() const
@@ -231,7 +236,6 @@ Utils::CommandLine ROSCatkinToolsStep::makeCommand(const QString &args) const
 
 void ROSCatkinToolsStep::stdOutput(const QString &line)
 {
-    AbstractProcessStep::stdOutput(line);
     QRegularExpressionMatchIterator i = m_percentProgress.globalMatch(line);
     while (i.hasNext()) {
         QRegularExpressionMatch match = i.next();

--- a/src/project_manager/ros_catkin_tools_step.h
+++ b/src/project_manager/ros_catkin_tools_step.h
@@ -70,7 +70,6 @@ public:
 
     QString allArguments(ROSUtils::BuildType buildType, bool includeDefault = true) const;
     Utils::CommandLine makeCommand(const QString &args) const;
-    void stdOutput(const QString &line) override;
 
     QVariantMap toMap() const override;
 
@@ -81,6 +80,7 @@ protected:
 
 private:
     ROSBuildConfiguration *targetsActiveBuildConfiguration() const;
+    void stdOutput(const QString &line);
 
     BuildTargets m_target;
     QString m_activeProfile;

--- a/src/project_manager/ros_colcon_step.cpp
+++ b/src/project_manager/ros_colcon_step.cpp
@@ -176,6 +176,7 @@ QString ROSColconStep::allArguments(ROSUtils::BuildType buildType, bool includeD
     case BUILD:
         args << QLatin1String("build");
         args << m_colconArguments;
+        args << "--event-handlers status+ console_start_end+";
         if (includeDefault)
             if (buildType == ROSUtils::BuildTypeUserDefined)
                 args << QString("--cmake-args -G \"CodeBlocks - Unix Makefiles\" %1").arg(m_cmakeArguments);

--- a/src/project_manager/ros_colcon_step.cpp
+++ b/src/project_manager/ros_colcon_step.cpp
@@ -66,6 +66,11 @@ ROSColconStep::ROSColconStep(BuildStepList *parent, const Utils::Id id) :
     ROSBuildConfiguration *bc = rosBuildConfiguration();
     if (bc->rosBuildSystem() != ROSUtils::Colcon)
         setEnabled(false);
+
+    connect(this, &BuildStep::addOutput, this, [this](const QString &string, OutputFormat format) {
+        if (format == OutputFormat::Stdout)
+            stdOutput(string);
+    });
 }
 
 ROSBuildConfiguration *ROSColconStep::rosBuildConfiguration() const
@@ -215,7 +220,6 @@ Utils::CommandLine ROSColconStep::makeCommand(const QString &args) const
 
 void ROSColconStep::stdOutput(const QString &line)
 {
-    AbstractProcessStep::stdOutput(line);
     QRegularExpressionMatchIterator i = m_percentProgress.globalMatch(line);
     while (i.hasNext()) {
         QRegularExpressionMatch match = i.next();

--- a/src/project_manager/ros_colcon_step.h
+++ b/src/project_manager/ros_colcon_step.h
@@ -59,7 +59,6 @@ public:
 
     QString allArguments(ROSUtils::BuildType buildType, bool includeDefault = true) const;
     Utils::CommandLine makeCommand(const QString &args) const;
-    void stdOutput(const QString &line) override;
 
     QVariantMap toMap() const override;
 
@@ -70,6 +69,7 @@ protected:
 
 private:
     ROSBuildConfiguration *targetsActiveBuildConfiguration() const;
+    void stdOutput(const QString &line);
 
     BuildTargets m_target;
     QString m_colconArguments;

--- a/src/project_manager/ros_import_wizard_page.ui
+++ b/src/project_manager/ros_import_wizard_page.ui
@@ -61,6 +61,9 @@
    </item>
    <item row="2" column="1">
     <widget class="QComboBox" name="buildSystemComboBox">
+     <property name="currentIndex">
+      <number>2</number>
+     </property>
      <item>
       <property name="text">
        <string>CatkinMake</string>

--- a/src/project_manager/ros_package_wizard.cpp
+++ b/src/project_manager/ros_package_wizard.cpp
@@ -275,10 +275,10 @@ Core::GeneratedFiles ROSPackageWizard::generateFiles(const QWizard *w,
     packagePath = packagePath.pathAppended(m_wizard->packageName()).pathAppended(QLatin1String("package.xml"));
     cmakelistPath = cmakelistPath.pathAppended(m_wizard->packageName()).pathAppended(QLatin1String("CMakeLists.txt"));
 
-    Core::GeneratedFile generatedPackageFile(packagePath.toString());
+    Core::GeneratedFile generatedPackageFile(packagePath);
     generatedPackageFile.setAttributes(Core::GeneratedFile::CustomGeneratorAttribute);
 
-    Core::GeneratedFile generatedCMakeListFile(cmakelistPath.toString());
+    Core::GeneratedFile generatedCMakeListFile(cmakelistPath);
     generatedCMakeListFile.setAttributes(Core::GeneratedFile::CustomGeneratorAttribute);
 
     Core::GeneratedFiles files;

--- a/src/project_manager/ros_project_wizard.cpp
+++ b/src/project_manager/ros_project_wizard.cpp
@@ -257,7 +257,7 @@ Core::GeneratedFiles ROSProjectWizard::generateFiles(const QWizard *w, QString *
     const QDir wsDir(wizard->workspaceDirectory().toString());
 
     const QString projectName = wizard->projectName();
-    const QString workspaceFileName = QFileInfo(wsDir, projectName + QLatin1String(".workspace")).absoluteFilePath();
+    const Utils::FilePath workspaceFileName = Utils::FilePath::fromFileInfo(QFileInfo(wsDir, projectName + QLatin1String(".workspace")));
     ROSUtils::ROSProjectFileContent projectFileContent;
     projectFileContent.defaultBuildSystem = wizard->buildSystem();
     projectFileContent.distribution = wizard->distribution();

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 # - https://download.qt.io/official_releases/qtcreator/
 # for valid versions
 # the version schema is: {major}[.{minor}][.{patch}][-{devel}]
-qtc_version: "9.0"
+qtc_version: "10"
 qtc_modules: ["qtcreator", "qtcreator_dev"]
 
 qt_version: "6.4"


### PR DESCRIPTION
In addition to the usual API changes, this PR:
- fixes parsing the progress of colcon builds
- makes colcon the default build system (colcon also supports ROS 1 workspaces, a.k.a. catkin)