### PR TITLE
add setup support for aarch64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,16 +33,18 @@ arch_map = {
     "aarch64": "arm64",
 }
 
-os_compiler = {
-    "Linux": "gcc",
-    "Windows": "msvc2019",
-    "Darwin": "clang",
-}
-
-arch_bits = {
-    "x86": "32",
-    "x64": "64",
-    "arm64": "64",
+os_arch_toolchain = {
+    "linux": {
+        "x64": "gcc_64",
+        "arm64": "linux_gcc_arm64",
+    },
+    "windows": {
+        "x64": "win64_msvc2019_64",
+        "arm64": "win64_msvc2019_arm64",
+    },
+    "mac": {
+        "x64": "clang_64",
+    },
 }
 
 def download_check_fail(url, expected_type):
@@ -156,21 +158,16 @@ def qt_download_check_extract(cfg, dir_install):
 
     metadata = ElementTree.fromstring(r.text)
 
-    compiler_bits = os_compiler[cfg['os']]+"_"+arch_bits[sys_arch]
-
-    if cfg['os'] == "Windows":
-        compiler = "win"+arch_bits[sys_arch]+"_"+compiler_bits
-    else:
-        compiler = compiler_bits
+    toolchain = os_arch_toolchain[sys_os][sys_arch]
 
     base_package_name = "qt.qt{ver_maj}.{ver_concat}.{compiler}".format(
         ver_maj = ver_maj, ver_concat = ver_concat,
-        compiler = compiler)
+        compiler = toolchain)
 
     extra_package_name = "qt.qt{ver_maj}.{ver_concat}.{module}.{compiler}".format(
         ver_maj = ver_maj, ver_concat = ver_concat,
         module = "{module}",
-        compiler = compiler)
+        compiler = toolchain)
 
     extra_package_names = list()
     for module in cfg['versions']['qt_modules']:

--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,9 @@ def qt_download_check_extract(cfg, dir_install):
                 if archive_name.startswith(module_name):
                     archives_match.append([package_name, data["version"], archive_name])
 
+    if not archives_match:
+        raise RuntimeError(f"no matches for Qt modules ({cfg['versions']['qt_modules']}) found")
+
     for package_name, package_version, archive_name in archives_match:
         url_archive = base_url+'/'+package_name+'/'+package_version+archive_name
 

--- a/setup.py
+++ b/setup.py
@@ -18,22 +18,32 @@ url_repo_qtc_fmt = "https://download.qt.io/{release_type}_releases/qtcreator/{qt
 
 url_repo_qt_fmt = "https://download.qt.io/online/qtsdkrepository/{os}_{arch}/desktop/qt{ver_maj}_{ver_concat}/"
 
-os_map = {"Linux": "linux",
-          "Windows": "windows",
-          "Darwin": "mac"}
+os_map = {
+    "Linux": "linux",
+    "Windows": "windows",
+    "Darwin": "mac",
+}
 
-arch_map = {"i386": "x86",
-            "i686": "x86",
-            "x86": "x86",
-            "x86_64": "x64",
-            "AMD64": "x64"}
+arch_map = {
+    "i386": "x86",
+    "i686": "x86",
+    "x86": "x86",
+    "x86_64": "x64",
+    "AMD64": "x64",
+    "aarch64": "arm64",
+}
 
-os_compiler = {"Linux": "gcc",
-               "Windows": "msvc2019",
-               "Darwin": "clang"}
+os_compiler = {
+    "Linux": "gcc",
+    "Windows": "msvc2019",
+    "Darwin": "clang",
+}
 
-arch_bits = {"x86": "32",
-             "x64": "64"}
+arch_bits = {
+    "x86": "32",
+    "x64": "64",
+    "arm64": "64",
+}
 
 def download_check_fail(url, expected_type):
     print("download URL:", url, flush=True)


### PR DESCRIPTION
Fixes https://github.com/ros-industrial/ros_qtc_plugin/issues/490.

However, the `linux_arm64` builds only support Qt 6.7 (https://download.qt.io/online/qtsdkrepository/linux_arm64/desktop/), hence you manually have to change `qt_version: "6.6"` -> `qt_version: "6.7"` in the `versions.yaml`.

Tested on the `arm64v8/ubuntu` Docker image with `multiarch/qemu-user-static`.