### PR TITLE
Qt Creator 13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       - name: install Qt and Qt Creator
         shell: bash
         run: |
-          pip install pyyaml requests py7zr tqdm_loggable
+          pip install pyyaml requests py7zr==0.21 tqdm_loggable
           python setup.py --export_variables
           cat env >> $GITHUB_ENV
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt update
-          sudo apt install libgl1-mesa-dev ninja-build libqtermwidget5-0-dev libutf8proc-dev
+          sudo apt install libgl1-mesa-dev ninja-build libutf8proc-dev
 
       - name: install Windows system dependencies
         if: runner.os == 'Windows'
@@ -36,7 +36,7 @@ jobs:
 
       - name: install macOS system dependencies
         if: runner.os == 'macOS'
-        run: brew install ninja qt5
+        run: brew install ninja
 
       - name: install yaml-cpp
         shell: bash
@@ -58,20 +58,6 @@ jobs:
           pip install pyyaml requests py7zr==0.21 tqdm_loggable
           python setup.py --export_variables
           cat env >> $GITHUB_ENV
-
-      - name: install qtermwidget
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          git clone https://github.com/lxqt/lxqt-build-tools.git extern/lxqt-build-tools
-          cd extern/lxqt-build-tools
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DQt5Core_DIR=$(brew --prefix qt5)/lib/cmake/Qt5Core
-          cmake --build build --target install
-          cd ../..
-          git clone https://github.com/lxqt/qtermwidget.git extern/qtermwidget
-          cd extern/qtermwidget
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DQt5Core_DIR=$(brew --prefix qt5)/lib/cmake/Qt5Core -DQt5Widgets_DIR=$(brew --prefix qt5)/lib/cmake/Qt5Widgets -DQt5LinguistTools_DIR=$(brew --prefix qt5)/lib/cmake/Qt5LinguistTools
-          cmake --build build --target install
 
       - name: build plugin
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(ROSProjectManager VERSION 12.0)
+project(ROSProjectManager VERSION 13.0)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wsuggest-override)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo apt install libgl1-mesa-dev ninja-build libyaml-cpp-dev libqtermwidget5-0-d
 
 To use the `setup.py` script, you will need additional python dependencies:
 ```bash
-pip install pyyaml requests py7zr
+pip install pyyaml requests py7zr==0.21
 ```
 
 ## Build

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ def extract_progress(archive_bytes, archive_name, destination_path):
             pass
         def report_start(self, processing_file_path, processing_bytes):
             pass
+        def report_update(self, decompressed_bytes):
+            pass
         def report_end(self, processing_file_path, wrote_bytes):
             self.update(int(wrote_bytes))
         def report_postprocess(self):

--- a/src/project_manager/ros_build_configuration.cpp
+++ b/src/project_manager/ros_build_configuration.cpp
@@ -177,7 +177,7 @@ ROSProject *ROSBuildConfiguration::project()
 
 void ROSBuildConfiguration::updateQtEnvironment(const Utils::Environment &env)
 {
-    const Utils::NameValueItems diff = baseEnvironment().diff(env);
+    const Utils::EnvironmentItems diff = baseEnvironment().diff(env);
     if (!diff.isEmpty())
       setUserEnvironmentChanges(diff);
 }

--- a/src/project_manager/ros_catkin_make_step.cpp
+++ b/src/project_manager/ros_catkin_make_step.cpp
@@ -91,7 +91,7 @@ bool ROSCatkinMakeStep::init()
     if (!bc)
         bc = targetsActiveBuildConfiguration();
 
-    ToolChain *tc = ToolChainKitAspect::toolChain(target()->kit(), ProjectExplorer::Constants::CXX_LANGUAGE_ID);
+    Toolchain *tc = ToolchainKitAspect::toolchain(target()->kit(), ProjectExplorer::Constants::CXX_LANGUAGE_ID);
 
     if (!tc)
         emit addTask(Task::compilerMissingTask());

--- a/src/project_manager/ros_catkin_tools_step.cpp
+++ b/src/project_manager/ros_catkin_tools_step.cpp
@@ -102,7 +102,7 @@ bool ROSCatkinToolsStep::init()
     if (!bc)
         bc = targetsActiveBuildConfiguration();
 
-    ToolChain *tc = ToolChainKitAspect::toolChain(target()->kit(), ProjectExplorer::Constants::CXX_LANGUAGE_ID);
+    Toolchain *tc = ToolchainKitAspect::toolchain(target()->kit(), ProjectExplorer::Constants::CXX_LANGUAGE_ID);
 
     if (!tc)
         emit addTask(Task::compilerMissingTask());

--- a/src/project_manager/ros_colcon_step.cpp
+++ b/src/project_manager/ros_colcon_step.cpp
@@ -91,7 +91,7 @@ bool ROSColconStep::init()
     if (!bc)
         bc = targetsActiveBuildConfiguration();
 
-    ToolChain *tc = ToolChainKitAspect::toolChain(target()->kit(), ProjectExplorer::Constants::CXX_LANGUAGE_ID);
+    Toolchain *tc = ToolchainKitAspect::toolchain(target()->kit(), ProjectExplorer::Constants::CXX_LANGUAGE_ID);
 
     if (!tc)
         emit addTask(Task::compilerMissingTask());

--- a/src/project_manager/ros_project.cpp
+++ b/src/project_manager/ros_project.cpp
@@ -551,7 +551,7 @@ void ROSProject::updateCppCodeModel()
     QtSupport::CppKitInfo kitInfo(this->activeTarget()->kit());
     QTC_ASSERT(kitInfo.isValid(), return);
 
-    m_cppCodeModelUpdater->update({this, kitInfo, rosBuildConfiguration()->environment(), m_futureBuildCodeModelWatcher.result().parts});
+    m_cppCodeModelUpdater->update({this, kitInfo, rosBuildConfiguration()->environment(), m_futureBuildCodeModelWatcher.result().parts}, {});
 
     m_asyncBuildCodeModelFutureInterface->reportFinished();
     delete m_asyncBuildCodeModelFutureInterface;

--- a/src/project_manager/ros_project.cpp
+++ b/src/project_manager/ros_project.cpp
@@ -481,7 +481,7 @@ void ROSProject::buildCppCodeModel(const ROSUtils::WorkspaceInfo workspaceInfo,
 
     ProjectExplorer::RawProjectParts rpps;
 
-    const ToolChain *cxxToolChain = ToolChainKitAspect::cxxToolChain(k);
+    const Toolchain *cxxToolChain = ToolchainKitAspect::cxxToolchain(k);
 
     if (cxxToolChain)
     {

--- a/src/project_manager/ros_project_plugin.cpp
+++ b/src/project_manager/ros_project_plugin.cpp
@@ -253,7 +253,7 @@ void ROSProjectPlugin::createCppCodeStyle()
 
   // Since the ROS Cpp code style can not be added until after the CppToolsSettings instance is create
   // the Cpp code style must be reloaded from settings to capture if it is set ROS Cpp code style.
-  CppEditor::CppCodeStylePreferences *originalCppCodeStylePreferences = CppEditor::CppToolsSettings::instance()->cppCodeStyle();
+  CppEditor::CppCodeStylePreferences *originalCppCodeStylePreferences = CppEditor::CppToolsSettings::cppCodeStyle();
   originalCppCodeStylePreferences->fromSettings(CppEditor::Constants::CPP_SETTINGS_ID);
 }
 

--- a/src/project_manager/ros_project_wizard.cpp
+++ b/src/project_manager/ros_project_wizard.cpp
@@ -124,6 +124,7 @@ ROSImportWizardPage::ROSImportWizardPage(QWidget *parent) :
 {
     d->m_ui.setupUi(this);
     QStringList dist_list;
+    dist_list.append(QString{});
     for(auto entry : ROSUtils::installedDistributions())
     {
         dist_list.append(entry.toString());

--- a/src/project_manager/ros_run_configuration.cpp
+++ b/src/project_manager/ros_run_configuration.cpp
@@ -67,14 +67,14 @@ ROSRunConfiguration::ROSRunConfiguration(Target *target, Utils::Id id) :
 }
 
 
-QString ROSRunConfiguration::disabledReason() const
+QString ROSRunConfiguration::disabledReason(Utils::Id runMode) const
 {
   QString output;
-  output = RunConfiguration::disabledReason();
+  output = RunConfiguration::disabledReason(runMode);
 
   if (output.isEmpty())
   {
-    if (!isEnabled())
+    if (!isEnabled(runMode))
         output = tr("No ROS run step for active project.");
   }
 

--- a/src/project_manager/ros_run_configuration.h
+++ b/src/project_manager/ros_run_configuration.h
@@ -53,7 +53,7 @@ public:
     ROSRunConfiguration(ProjectExplorer::Target *target, Utils::Id id);
 
     // RunConfiguration
-    QString disabledReason() const override;
+    QString disabledReason(Utils::Id runMode) const override;
 
     RunStepList *stepList() const;
 

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -348,9 +348,12 @@ bool ROSUtils::generateQtCreatorWorkspaceFile(QXmlStreamWriter &xmlFile, const R
     xmlFile.writeStartDocument();
     xmlFile.writeStartElement(QLatin1String("Workspace"));
 
-    xmlFile.writeStartElement(QLatin1String("Distribution"));
-    xmlFile.writeAttribute(QLatin1String("path"), content.distribution.toString());
-    xmlFile.writeEndElement();
+    if (!content.distribution.path().trimmed().isEmpty())
+    {
+        xmlFile.writeStartElement(QLatin1String("Distribution"));
+        xmlFile.writeAttribute(QLatin1String("path"), content.distribution.toString());
+        xmlFile.writeEndElement();
+    }
 
     xmlFile.writeStartElement(QLatin1String("DefaultBuildSystem"));
     xmlFile.writeAttribute(QLatin1String("value"), QString::number(content.defaultBuildSystem));

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -407,7 +407,7 @@ bool ROSUtils::parseQtCreatorWorkspaceFile(const Utils::FilePath &filePath, ROSP
                 }
                 else
                 {
-                    content.defaultBuildSystem = ROSUtils::CatkinMake;
+                    content.defaultBuildSystem = ROSUtils::Colcon;
                     Core::MessageManager::writeSilently(QObject::tr("[ROS Warning] Project file DefaultBuildSystem tag did not have a value attribute."));
                 }
 

--- a/src/project_manager/ros_utils.h
+++ b/src/project_manager/ros_utils.h
@@ -433,9 +433,8 @@ private:
      * @brief sourceWorkspaceHelper - Source workspace helper function
      * @param process - QProcess to execute source bash command
      * @param path - Path to workspace setup.bash
-     * @return True if successful
      */
-    static bool sourceWorkspaceHelper(QProcess *process, const QString &path);
+    static void sourceWorkspaceHelper(QProcess *process, const QString &path);
 
     /**
      * @brief This will parse the CodeBlock file and get the build info (incudes, Cxx Flags, etc.)

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 # - https://download.qt.io/official_releases/qtcreator/
 # for valid versions
 # the version schema is: {major}[.{minor}][.{patch}][-{devel}]
-qtc_version: "12"
+qtc_version: "13"
 qtc_modules: ["qtcreator", "qtcreator_dev"]
 
 qt_version: "6.6"


### PR DESCRIPTION
With this PR I am also adding the option to use a plain colcon environment without a ROS installation. In this case, the environment will only consist of `QProcessEnvironment::systemEnvironment()`. However, if Qt Creator is started in an already source ROS environment, then this will also contain this sourced ROS environment even when none is selected.

Fixes https://github.com/ros-industrial/ros_qtc_plugin/issues/492.