### PR TITLE
 restructure the documentation and add instructions for debugging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,9 @@ if __name__ == "__main__":
 
     dir_install = args.install_path
     if not dir_install:
-        dir_install = os.path.join(tempfile.gettempdir(), "qtc_sdk")
+        dir_install = os.path.join(tempfile.gettempdir())
+
+    dir_install = os.path.join(dir_install, "qtc-sdk")
 
     os.makedirs(dir_install, exist_ok=True)
 


### PR DESCRIPTION
The documentation should now be a bit more concise when you just want to install Qt Creator and/or the plugin in binary form. I added a section on how to debug the plugin. This is mainly how to launch Qt Creator with a manually provided path to the plugin with debug symbols.