### PR TITLE
keep empty environment variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(ROSProjectManager VERSION 13.0)
+project(ROSProjectManager VERSION 13.1)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wsuggest-override)

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -331,8 +331,7 @@ void ROSUtils::sourceWorkspaceHelper(QProcess *process, const QString &path)
       if (process->exitStatus() != QProcess::CrashExit)
       {
         while (process->canReadLine()) {
-            const QStringList env_kv = QString::fromLocal8Bit(process->readLine().trimmed())
-                                           .split('=', Qt::SkipEmptyParts);
+            const QStringList env_kv = QString::fromLocal8Bit(process->readLine().trimmed()).split('=');
             env.insert(env_kv[0], env_kv[1]);
         }
       }


### PR DESCRIPTION
This handles cases where an empty environment variable, e.g. `VAR=`, is parsed.

Fixes #496.