### PR TITLE
update the online Qt Creator download URL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         config:
           - { name: "Linux", os: ubuntu-20.04 }
           - { name: "Windows", os: windows-latest }
-          - { name: "macOS", os: macos-latest }
+          - { name: "macOS", os: macos-13 }
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo snap install qtcreator-ros --classic
 
 ### Manual Qt Creator and Plugin Installation
 
-Qt Creator can be installed via the official [online](https://www.qt.io/download-thank-you) and [offline](https://www.qt.io/offline-installers) installer.
+Qt Creator can be installed via the official [online](https://www.qt.io/download-qt-installer-oss) and [offline](https://www.qt.io/offline-installers) installer.
 
 Download the plugin archive from the [release page](https://github.com/ros-industrial/ros_qtc_plugin/releases/latest) and extract it into the root of a Qt Creator installation. The Qt Creator root will be `~/Qt/Tools/QtCreator` for the online installer and `~/qtcreator-${version}` for the offline installer.
 


### PR DESCRIPTION
`macos-latest` now uses arm64 runnter (`macos-14-arm64`) but there are no binary distributions for this yet (https://download.qt.io/official_releases/qtcreator/13.0/13.0.1/installer_source/). Revert this back to `macos-13` until `arm64` binaries are available.