### PR TITLE
add macOS 14 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         config:
           - { name: "Linux", os: ubuntu-20.04 }
           - { name: "Windows", os: windows-latest }
-          - { name: "macOS", os: macos-13 }
+          - { name: "macOS", os: macos-14 }
     steps:
       - uses: actions/checkout@v4
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ from xml.etree import ElementTree
 import py7zr
 import requests
 import yaml
-from tqdm_loggable.auto import tqdm
+try:
+    from tqdm_loggable.auto import tqdm
+except ModuleNotFoundError:
+    from tqdm import tqdm
 
 
 url_repo_qtc_fmt = "https://download.qt.io/{release_type}_releases/qtcreator/{qtcv_maj}/{qtcv_full}/installer_source/{os}_{arch}/"

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ arch_map = {
     "i686": "x86",
     "x86": "x86",
     "x86_64": "x64",
+    "x64": "x64",
     "AMD64": "x64",
     "aarch64": "arm64",
 }
@@ -224,6 +225,10 @@ if __name__ == "__main__":
 
     cfg['os'] = platform.system()
     cfg['arch'] = platform.machine()
+
+    # macOS uses a universal binary that stores all architectures in the "x64" folder
+    if cfg['os'] == "Darwin":
+        cfg['arch'] = "x64"
 
     with open("versions.yaml", 'r') as file:
         cfg['versions'] = yaml.safe_load(file)


### PR DESCRIPTION
On macOS arm64 we need a workaround since the arm64 and x64 architectures map to the same download path due to the universal binaries.