### PR TITLE
remove make arg option from colcon

### DIFF
--- a/src/project_manager/ros_colcon_step.cpp
+++ b/src/project_manager/ros_colcon_step.cpp
@@ -51,7 +51,6 @@ const char ROS_COLCON_STEP_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("ROSProjectManager
 const char ROS_COLCON_STEP[] = "ROSProjectManager.ROSColconStep.Target";
 const char ROS_COLCON_STEP_ARGUMENTS_KEY[] = "ROSProjectManager.ROSColconStep.ColconArguments";
 const char ROS_COLCON_STEP_CMAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSColconStep.CMakeArguments";
-const char ROS_COLCON_STEP_MAKE_ARGUMENTS_KEY[] = "ROSProjectManager.ROSColconStep.MakeArguments";
 
 ROSColconStep::ROSColconStep(BuildStepList *parent, const Utils::Id id) :
     AbstractProcessStep(parent, id)
@@ -147,7 +146,6 @@ void ROSColconStep::toMap(Utils::Store &map) const
     map.insert(ROS_COLCON_STEP, m_target);
     map.insert(ROS_COLCON_STEP_ARGUMENTS_KEY, m_colconArguments);
     map.insert(ROS_COLCON_STEP_CMAKE_ARGUMENTS_KEY, m_cmakeArguments);
-    map.insert(ROS_COLCON_STEP_MAKE_ARGUMENTS_KEY, m_makeArguments);
 }
 
 void ROSColconStep::fromMap(const Utils::Store &map)
@@ -155,7 +153,6 @@ void ROSColconStep::fromMap(const Utils::Store &map)
     m_target = (BuildTargets)map.value(ROS_COLCON_STEP).toInt();
     m_colconArguments = map.value(ROS_COLCON_STEP_ARGUMENTS_KEY).toString();
     m_cmakeArguments = map.value(ROS_COLCON_STEP_CMAKE_ARGUMENTS_KEY).toString();
-    m_makeArguments = map.value(ROS_COLCON_STEP_MAKE_ARGUMENTS_KEY).toString();
 
     BuildStep::fromMap(map);
 }
@@ -189,9 +186,6 @@ QString ROSColconStep::allArguments(ROSUtils::BuildType buildType, bool includeD
 
         break;
     }
-
-    if (!m_makeArguments.isEmpty())
-        args << QString("--make-args %1").arg(m_makeArguments);
 
     return args.join(" ");
 }
@@ -250,7 +244,6 @@ ROSColconStepWidget::ROSColconStepWidget(ROSColconStep *makeStep)
 
     m_ui->colconArgumentsLineEdit->setText(m_makeStep->m_colconArguments);
     m_ui->cmakeArgumentsLineEdit->setText(m_makeStep->m_cmakeArguments);
-    m_ui->makeArgumentsLineEdit->setText(m_makeStep->m_makeArguments);
 
     updateDetails();
 
@@ -258,9 +251,6 @@ ROSColconStepWidget::ROSColconStepWidget(ROSColconStep *makeStep)
             this, &ROSColconStepWidget::updateDetails);
 
     connect(m_ui->cmakeArgumentsLineEdit, &QLineEdit::textEdited,
-            this, &ROSColconStepWidget::updateDetails);
-
-    connect(m_ui->makeArgumentsLineEdit, &QLineEdit::textEdited,
             this, &ROSColconStepWidget::updateDetails);
 
     connect(m_makeStep, SIGNAL(enabledChanged()),
@@ -294,7 +284,6 @@ void ROSColconStepWidget::updateDetails()
 {
     m_makeStep->m_colconArguments = m_ui->colconArgumentsLineEdit->text();
     m_makeStep->m_cmakeArguments = m_ui->cmakeArgumentsLineEdit->text();
-    m_makeStep->m_makeArguments = m_ui->makeArgumentsLineEdit->text();
 
     ROSBuildConfiguration *bc = m_makeStep->rosBuildConfiguration();
     ROSUtils::WorkspaceInfo workspaceInfo = ROSUtils::getWorkspaceInfo(bc->project()->projectDirectory(), bc->rosBuildSystem(), bc->project()->distribution());

--- a/src/project_manager/ros_colcon_step.h
+++ b/src/project_manager/ros_colcon_step.h
@@ -74,7 +74,6 @@ private:
     BuildTargets m_target;
     QString m_colconArguments;
     QString m_cmakeArguments;
-    QString m_makeArguments;
     QRegularExpression m_percentProgress;
 };
 

--- a/src/project_manager/ros_colcon_step.ui
+++ b/src/project_manager/ros_colcon_step.ui
@@ -7,12 +7,12 @@
     <x>0</x>
     <y>0</y>
     <width>545</width>
-    <height>105</height>
+    <height>79</height>
    </rect>
   </property>
   <layout class="QFormLayout" name="formLayout">
    <property name="fieldGrowthPolicy">
-    <enum>QFormLayout::ExpandingFieldsGrow</enum>
+    <enum>QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow</enum>
    </property>
    <property name="leftMargin">
     <number>9</number>
@@ -52,22 +52,6 @@
    </item>
    <item row="1" column="1">
     <widget class="QLineEdit" name="cmakeArgumentsLineEdit"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="makeArgumentsLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Make Arguments:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="makeArgumentsLineEdit"/>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
colcon does not have a `--make-args` parameter. This seems to have been copied from catkin. Setting `Make Arguments` in the step UI will thus cause an error. Fixes https://github.com/ros-industrial/ros_qtc_plugin/issues/507.