### PR TITLE
use yaml-cpp from the Qt Creator SDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,20 +38,6 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install ninja
 
-      - name: install yaml-cpp
-        shell: bash
-        run: |
-          git clone --depth 1 https://github.com/jbeder/yaml-cpp.git extern/yaml-cpp --branch yaml-cpp-0.7.0
-          cd extern/yaml-cpp
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DYAML_CPP_BUILD_TESTS=OFF
-          $(which sudo) cmake --build build --target install
-
-      - name: set build environment variables (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          echo "YAML_DIR='C:/Program Files (x86)/YAML_CPP/share/cmake/yaml-cpp/'" >> $GITHUB_ENV
-
       - name: install Qt and Qt Creator
         shell: bash
         run: |
@@ -61,7 +47,7 @@ jobs:
 
       - name: build plugin
         run: |
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${{ env.QTC_PATH }};${{ env.QT_PATH }}" -Dyaml-cpp_DIR=${{ env.YAML_DIR }} -DBUILD_ROSTERMINAL=OFF
+          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${{ env.QTC_PATH }};${{ env.QT_PATH }}" -DBUILD_ROSTERMINAL=OFF
           cmake --build build --target package
 
       - name: find plugin archive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(ROSProjectManager VERSION 14.0)
+project(ROSProjectManager VERSION 14.1)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wsuggest-override)

--- a/README.md
+++ b/README.md
@@ -56,12 +56,11 @@ To build the Qt Creator plugin, you will need Qt Creator, the matching "Plugin D
 Additionally, you need:
 - OpenGL development libraries
 - ninja for building
-- yaml-cpp
 - utf8proc
 
 The dependencies can be installed via apt on Ubuntu:
 ```bash
-sudo apt install libgl1-mesa-dev ninja-build libyaml-cpp-dev libutf8proc-dev
+sudo apt install libgl1-mesa-dev ninja-build libutf8proc-dev
 ```
 
 The `setup.py` script needs additional Python dependencies:

--- a/src/project_manager/CMakeLists.txt
+++ b/src/project_manager/CMakeLists.txt
@@ -5,7 +5,6 @@ set(CMAKE_CXX_STANDARD 17)
 
 find_package(QtCreator COMPONENTS Core REQUIRED)
 find_package(QT NAMES Qt6 COMPONENTS Widgets REQUIRED)
-find_package(yaml-cpp REQUIRED)
 
 set(SRC
   "remove_directory_dialog.cpp"
@@ -50,8 +49,8 @@ add_qtc_plugin(${PROJECT_NAME}
     QtCreator::TextEditor
   DEPENDS
     QtCreator::Utils
+    QtCreator::yaml-cpp
     Qt::Widgets
-    yaml-cpp
   SOURCES
     ${SRC}
 )


### PR DESCRIPTION
The Qt Creator SDK ships its own 3rd party variant of `libyaml-cpp` (target `QtCreator::yaml-cpp`). Using this instead of the system or external version reduces compilation time and maintenance burden.