### PR TITLE
add Wayland support via launcher an fix StartupWMClass

### DIFF
--- a/packaging/launcher.cmake
+++ b/packaging/launcher.cmake
@@ -5,7 +5,11 @@ execute_process(
 )
 
 execute_process(
-    COMMAND desktop-file-edit "${CMAKE_CURRENT_BINARY_DIR}/usr/share/applications/qtcreator-ros.desktop" "--set-key=Exec" "--set-value=/opt/qt-creator/bin/qtcreator %F" "--set-key=Name" "--set-value=Qt Creator ROS" "--set-key=Icon" "--set-value=/usr/share/icons/hicolor/qtcreator-ros.svg"
+    COMMAND desktop-file-edit "${CMAKE_CURRENT_BINARY_DIR}/usr/share/applications/qtcreator-ros.desktop"
+                              "--set-key=Exec" "--set-value=env QT_QPA_PLATFORM=\"wayland;xcb\" /opt/qt-creator/bin/qtcreator %F"
+                              "--set-key=Name" "--set-value=Qt Creator ROS"
+                              "--set-key=Icon" "--set-value=/usr/share/icons/hicolor/qtcreator-ros.svg"
+                              "--set-key=StartupWMClass" "--set-value=org.qt-project.qtcreator"
     COMMAND_ERROR_IS_FATAL ANY
 )
 


### PR DESCRIPTION
On newer Ubuntu versions (22.04 upwards) Qt Creator and other X11 apps run via XWayland on Wayland. With fractional scaling, this make the window and especially text blurry and more difficult to read. Fix this by enabling Wayland support in Qt by setting `QT_QPA_PLATFORM` in the launcher.