### PR TITLE
replace deprecated "ubuntu-20.04" runner with "ubuntu-22.04"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - { name: "Linux", os: ubuntu-20.04, build: "RelWithDebInfo" }
+          - { name: "Linux", os: ubuntu-22.04, build: "RelWithDebInfo" }
           - { name: "Linux-arm64", os: ubuntu-24.04-arm, build: "RelWithDebInfo" }
           - { name: "Windows", os: windows-latest, build: "Release" }
           - { name: "macOS", os: macos-14, build: "Release" }


### PR DESCRIPTION
The Ubuntu 20.04 runner will start to brownout in February and become deprecated by April. See https://github.com/actions/runner-images/issues/11101.