### PR TITLE
check parsed list of strings

### DIFF
--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -328,7 +328,9 @@ void ROSUtils::sourceWorkspaceHelper(QProcessEnvironment &env, const QString &pa
 
     while (process.canReadLine()) {
         const QStringList env_kv = QString::fromLocal8Bit(process.readLine().trimmed()).split('=');
-        env.insert(env_kv[0], env_kv[1]);
+        if (env_kv.size() == 2) {
+            env.insert(env_kv[0], env_kv[1]);
+        }
     }
 }
 


### PR DESCRIPTION
This should avoid accessing elements outside the list bounds if the list is shorter than 2. Fixes #535.