### PR TITLE
add ROS distributions search path for Windows

### DIFF
--- a/src/project_manager/ros_generic_run_step.cpp
+++ b/src/project_manager/ros_generic_run_step.cpp
@@ -20,6 +20,7 @@
  */
 #include "ros_generic_run_step.h"
 #include "ros_project.h"
+#include "ros_project_constants.h"
 #include "ros_build_configuration.h"
 #include "ui_ros_generic_configuration.h"
 
@@ -86,9 +87,9 @@ void ROSGenericRunStep::run()
   if (workspaceInfo.install)
     sourcePath = Utils::FilePath(workspaceInfo.installPath);
 
-  Utils::FilePath source_bash_file = sourcePath.pathAppended("setup.bash");
-  Utils::FilePath source_shell_file = sourcePath.pathAppended("setup.sh");
-  Utils::FilePath source_zshell_file = sourcePath.pathAppended("setup.zsh");
+  const Utils::FilePath source_bash_file = sourcePath.pathAppended(Constants::ROS_SOURCE_FILE_BASH);
+  const Utils::FilePath source_shell_file = sourcePath.pathAppended(Constants::ROS_SOURCE_FILE_SHELL);
+  const Utils::FilePath source_zshell_file = sourcePath.pathAppended(Constants::ROS_SOURCE_FILE_ZSH);
 
   if (shell.fileName() == "bash")
   {

--- a/src/project_manager/ros_project_constants.h
+++ b/src/project_manager/ros_project_constants.h
@@ -39,7 +39,20 @@ static constexpr char ROS_READING_PROJECT[] = "ROSProjectManager.ReadingProject"
 static constexpr char ROS_RELOADING_BUILD_INFO[] = "ROSProjectManager.ReloadingBuildInfo";
 
 // ROS default install directory
+static const QString ROS_SOURCE_FILE_SHELL = "setup.sh";
+static const QString ROS_SOURCE_FILE_BASH = "setup.bash";
+static const QString ROS_SOURCE_FILE_ZSH = "setup.zsh";
+static const QString ROS_SOURCE_FILE_BAT = "setup.bat";
+#if defined(Q_OS_WIN)
+static constexpr char ROS_INSTALL_DIRECTORY[] = "C:/ros";
+static const QString ROS_SOURCE_FILE = ROS_SOURCE_FILE_BAT;
+#elif defined(Q_OS_MAC)
+static constexpr char ROS_INSTALL_DIRECTORY[] = "/usr/local/opt/ros";
+static const QString ROS_SOURCE_FILE = ROS_SOURCE_FILE_ZSH;
+#else
 static constexpr char ROS_INSTALL_DIRECTORY[] = "/opt/ros";
+static const QString ROS_SOURCE_FILE = ROS_SOURCE_FILE_BASH;
+#endif
 
 // Context menu actions
 static constexpr char ROS_RELOAD_BUILD_INFO[] = "ROSProjectManager.reloadProjectBuildInfo";

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -65,7 +65,7 @@ QString ROSUtils::buildTypeName(const ROSUtils::BuildType buildType)
 
 bool ROSUtils::sourceROS(QProcessEnvironment &env, const Utils::FilePath &rosDistribution)
 {
-  sourceWorkspaceHelper(env, Utils::FilePath(rosDistribution).pathAppended(QStringLiteral("setup.bash")).toFSPathString());
+  sourceWorkspaceHelper(env, Utils::FilePath(rosDistribution).pathAppended(Constants::ROS_SOURCE_FILE_BASH).toFSPathString());
   return true;
 }
 
@@ -78,8 +78,8 @@ bool ROSUtils::sourceWorkspace(QProcessEnvironment &env, const WorkspaceInfo &wo
     if (workspaceInfo.install)
       sourcePath = Utils::FilePath(workspaceInfo.installPath);
 
-    Utils::FilePath source_bash_file = sourcePath.pathAppended("setup.bash");
-    Utils::FilePath source_shell_file = sourcePath.pathAppended("setup.sh");
+    const Utils::FilePath source_bash_file = sourcePath.pathAppended(Constants::ROS_SOURCE_FILE_BASH);
+    const Utils::FilePath source_shell_file = sourcePath.pathAppended(Constants::ROS_SOURCE_FILE_SHELL);
     QString source_path;
     if (source_bash_file.exists())
     {
@@ -283,7 +283,7 @@ const QList<Utils::FilePath> ROSUtils::installedDistributions()
     const Utils::FilePaths entries = custom_ros_path.dirEntries(QDir::NoDotAndDotDot | QDir::Dirs);
     for (const Utils::FilePath &entry : entries)
     {
-      if ((entry / "setup.bash").exists())
+      if ((entry / Constants::ROS_SOURCE_FILE).exists())
       {
         distributions.append(custom_ros_path);
       }
@@ -296,7 +296,7 @@ const QList<Utils::FilePath> ROSUtils::installedDistributions()
     const Utils::FilePaths entries = default_ros_path.dirEntries(QDir::NoDotAndDotDot | QDir::Dirs);
     for (const Utils::FilePath &entry : entries)
     {
-      if ((entry / "setup.bash").exists())
+      if ((entry / Constants::ROS_SOURCE_FILE).exists())
       {
         distributions.append(entry);
       }


### PR DESCRIPTION
This sets the ROS distro search path per OS. On Windows, this is `C:/ros`, i.e. the plugin will discover ROS distributions under `C:/ros/jazzy` as `jazzy` and source the `setup.bat` inside this folder.

Fixes https://github.com/ros-industrial/ros_qtc_plugin/issues/541.